### PR TITLE
support version specific search on a per query basis

### DIFF
--- a/src/main/java/org/apache/platypus/server/luceneserver/IndexState.java
+++ b/src/main/java/org/apache/platypus/server/luceneserver/IndexState.java
@@ -1008,4 +1008,30 @@ public class IndexState implements Closeable {
         return result;
     }
 
+    /** Holds metadata for one snapshot, including its id, and
+     *  the index, taxonomy and state generations. */
+    public static class Gens {
+
+        /** Index generation. */
+        public final long indexGen;
+
+        /** Taxonomy index generation. */
+        public final long taxoGen;
+
+        /** State generation. */
+        public final long stateGen;
+
+        /** Snapshot id. */
+        public final String id;
+
+        /** Sole constructor. */
+        public Gens(long indexGen, long taxoGen, long stateGen, String id) {
+            this.indexGen = indexGen;
+            this.taxoGen = taxoGen;
+            this.stateGen = stateGen;
+            this.id = id;
+        }
+    }
+
+
 }

--- a/src/main/java/org/apache/platypus/server/luceneserver/ShardState.java
+++ b/src/main/java/org/apache/platypus/server/luceneserver/ShardState.java
@@ -736,6 +736,16 @@ public class ShardState implements Closeable {
             manager.addListener(listener);
         }
     }
+    public void removeRefreshListener(ReferenceManager.RefreshListener listener) {
+        if (nrtPrimaryNode != null) {
+            nrtPrimaryNode.getSearcherManager().removeListener(listener);
+        } else if (nrtReplicaNode != null) {
+            nrtReplicaNode.getSearcherManager().removeListener(listener);
+        } else {
+            manager.removeListener(listener);
+        }
+    }
+
 
 
     public void maybeRefreshBlocking() throws IOException {

--- a/src/main/proto/luceneserver.proto
+++ b/src/main/proto/luceneserver.proto
@@ -359,6 +359,11 @@ message SearchRequest {
     repeated VirtualField virtualFielsd = 7; //Defines virtual fields (name'd dynamic expressions) for this query.
     string query = 8; //TODO: not implemented. Full query to execute using QueryNodes
     QuerySortField querySort = 9; //Sort hits by field (default is by relevance).
+    oneof Searcher {
+        int64 indexGen = 10; //Search a generation previously returned by an indexing operation such as #addDocument.  Use this to search a non-committed (near-real-time) view of the index.
+        int64 version = 11;  //Search a specific searcher version.  This is typically used by follow-on searches (e.g., user clicks next page, drills down, or changes sort, etc.) to get the same searcher used by the original search.
+        string snapshot = 12; //Search a snapshot previously created with #createSnapshot
+    }
 }
 
 message SearchResponse {

--- a/src/test/java/org/apache/platypus/server/grpc/ReplicationServerTest.java
+++ b/src/test/java/org/apache/platypus/server/grpc/ReplicationServerTest.java
@@ -165,23 +165,16 @@ public class ReplicationServerTest {
                 .setIndexName(luceneServerPrimary.getTestIndex())
                 .setStartHit(0)
                 .setTopHits(10)
+                .setVersion(searcherVersionPrimary.getVersion())
                 .addAllRetrieveFields(RETRIEVED_VALUES)
                 .build());
-
-        //get searcherVersion on replica. Does it have primary searcher version yet?
-        long replicaSearcherVersion = 0;
-        while (replicaSearcherVersion != searcherVersionPrimary.getVersion()) {
-            SearcherVersion searcherVersionReplica = replicationServerSecondary.getReplicationServerBlockingStub().getCurrentSearcherVersion(IndexName.newBuilder().setIndexName("test_index").build());
-            replicaSearcherVersion = searcherVersionReplica.getVersion();
-            Thread.sleep(10);
-        }
-        assertEquals(replicaSearcherVersion, searcherVersionPrimary.getVersion());
 
         // replica should too!
         SearchResponse searchResponseSecondary = luceneServerSecondary.getBlockingStub().search(SearchRequest.newBuilder()
                 .setIndexName(luceneServerSecondary.getTestIndex())
                 .setStartHit(0)
                 .setTopHits(10)
+                .setVersion(searcherVersionPrimary.getVersion())
                 .addAllRetrieveFields(RETRIEVED_VALUES)
                 .build());
 


### PR DESCRIPTION
Search queries can specify searcher version to use. This is important to get a consistent-point-in-time view from different replicas and primary. For example `writeNRT` returns a search version, this version can be used on search queries to replica to ensure that the underlying searched data is consistent that was indexed on primary post its refresh.
