### PR TITLE
add more primary failure/crash tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ jdk:
   - oraclejdk12
 
 script:
-  - ./gradlew clean check test
+  - ./gradlew clean check test --info

--- a/src/main/java/org/apache/platypus/server/luceneserver/NRTReplicaNode.java
+++ b/src/main/java/org/apache/platypus/server/luceneserver/NRTReplicaNode.java
@@ -148,8 +148,7 @@ public class NRTReplicaNode extends ReplicaNode {
 
     @Override
     public void close() throws IOException {
-        //TODO: copy jobs running in their own thread
-        //jobs.close();
+        jobs.close();
         logger.info("CLOSE NRT REPLICA");
         message("top: jobs closed");
         synchronized (mergeCopyJobs) {

--- a/src/main/java/org/apache/platypus/server/luceneserver/SimpleCopyJob.java
+++ b/src/main/java/org/apache/platypus/server/luceneserver/SimpleCopyJob.java
@@ -19,13 +19,22 @@
 
 package org.apache.platypus.server.luceneserver;
 
-import org.apache.lucene.replicator.nrt.*;
-import org.apache.lucene.util.IOUtils;
+import org.apache.lucene.replicator.nrt.CopyJob;
+import org.apache.lucene.replicator.nrt.CopyOneFile;
+import org.apache.lucene.replicator.nrt.CopyState;
+import org.apache.lucene.replicator.nrt.FileMetaData;
+import org.apache.lucene.replicator.nrt.Node;
+import org.apache.lucene.replicator.nrt.NodeCommunicationException;
+import org.apache.lucene.replicator.nrt.ReplicaNode;
 import org.apache.platypus.server.grpc.RawFileChunk;
 import org.apache.platypus.server.grpc.ReplicationServerClient;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
 
 public class SimpleCopyJob extends CopyJob {
     final byte[] copyBuffer = new byte[65536];
@@ -56,10 +65,10 @@ public class SimpleCopyJob extends CopyJob {
         if (iter == null) {
             iter = toCopy.iterator();
             // This means we resumed an already in-progress copy; we do this one first:
-            if(current != null) {
+            if (current != null) {
                 totBytes += current.metaData.length;
             }
-            for (Map.Entry<String,FileMetaData> ent : toCopy) {
+            for (Map.Entry<String, FileMetaData> ent : toCopy) {
                 FileMetaData metaData = ent.getValue();
                 totBytes += metaData.length;
             }
@@ -132,11 +141,6 @@ public class SimpleCopyJob extends CopyJob {
 
         // nocommit syncMetaData here?
         copiedFiles.clear();
-        //ugh sad! delete temp file in base class, since "out" in base class is private and we have our own in this class.
-//        String tempFileResourceString = out.toString();
-//        Path unusedTempFile = Paths.get(tempFileResourceString.split("\"")[1].split("index")[0], "index", super.tmpName);
-//        Files.deleteIfExists(unusedTempFile);
-
 
     }
 

--- a/src/test/java/org/apache/platypus/server/grpc/GrpcServer.java
+++ b/src/test/java/org/apache/platypus/server/grpc/GrpcServer.java
@@ -170,11 +170,15 @@ public class GrpcServer {
         public boolean completed = false;
         public boolean error = false;
 
-        TestServer(GrpcServer grpcServer, boolean startIndex, Mode mode) throws IOException {
+        TestServer(GrpcServer grpcServer, boolean startIndex, Mode mode, int primaryGen) throws IOException {
             this.grpcServer = grpcServer;
             if (startIndex) {
-                new IndexAndRoleManager(grpcServer).createStartIndexAndRegisterFields(mode);
+                new IndexAndRoleManager(grpcServer).createStartIndexAndRegisterFields(mode, primaryGen);
             }
+        }
+
+        TestServer(GrpcServer grpcServer, boolean startIndex, Mode mode) throws IOException {
+            this(grpcServer, startIndex, mode, 0);
         }
 
         public void addDocuments() throws IOException, InterruptedException {
@@ -236,6 +240,10 @@ public class GrpcServer {
         }
 
         public FieldDefResponse createStartIndexAndRegisterFields(Mode mode) throws IOException {
+            return createStartIndexAndRegisterFields(mode, 0);
+        }
+
+        public FieldDefResponse createStartIndexAndRegisterFields(Mode mode, int primaryGen) throws IOException {
             String rootDirName = grpcServer.getRootDirName();
             String testIndex = grpcServer.getTestIndex();
             LuceneServerGrpc.LuceneServerBlockingStub blockingStub = grpcServer.getBlockingStub();
@@ -245,7 +253,7 @@ public class GrpcServer {
             StartIndexRequest.Builder startIndexBuilder = StartIndexRequest.newBuilder().setIndexName(testIndex);
             if (mode.equals(Mode.PRIMARY)) {
                 startIndexBuilder.setMode(Mode.PRIMARY);
-                startIndexBuilder.setPrimaryGen(0);
+                startIndexBuilder.setPrimaryGen(primaryGen);
             } else if (mode.equals(Mode.REPLICA)) {
                 startIndexBuilder.setMode(Mode.REPLICA);
                 startIndexBuilder.setPrimaryAddress("localhost");

--- a/src/test/java/org/apache/platypus/server/grpc/ReplicationTestFailureScenarios.java
+++ b/src/test/java/org/apache/platypus/server/grpc/ReplicationTestFailureScenarios.java
@@ -183,7 +183,6 @@ public class ReplicationTestFailureScenarios {
         testServerPrimary.addDocuments();
         publishNRTAndValidateSearchResults(4);
 
-
     }
 
     private void gracefullRestartSecondary() {


### PR DESCRIPTION
Added tests for 
1. non graceful primary shutdown i.e. primary dies and fresh primary has a clean state and index dir
2. graceful primary shutdown i.e. primary stop and restarts but keeps old state dir and index dir.