### PR TITLE
support suggestions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ primary_state/
 replica_state/
 serverPrimary/
 serverSecondary/
+server1RootDirName1/

--- a/src/main/java/org/apache/platypus/server/grpc/LuceneServer.java
+++ b/src/main/java/org/apache/platypus/server/grpc/LuceneServer.java
@@ -644,6 +644,24 @@ public class LuceneServer {
             }
         }
 
+        @Override
+        public void updateSuggest(BuildSuggestRequest buildSuggestRequest, StreamObserver<BuildSuggestResponse> responseObserver) {
+            try {
+                IndexState indexState = globalState.getIndex(buildSuggestRequest.getIndexName());
+                UpdateSuggestHandler updateSuggestHandler = new UpdateSuggestHandler();
+                BuildSuggestResponse reply = updateSuggestHandler.handle(indexState, buildSuggestRequest);
+                logger.info(String.format("UpdateSuggestHandler returned results %s", reply.toString()));
+                responseObserver.onNext(reply);
+                responseObserver.onCompleted();
+            } catch (Exception e) {
+                logger.warn(String.format("error while trying to update suggester %s for index %s", buildSuggestRequest.getSuggestName(), buildSuggestRequest.getIndexName()), e);
+                responseObserver.onError(Status
+                        .UNKNOWN
+                        .withDescription(String.format("error while trying to update suggester %s for index %s", buildSuggestRequest.getSuggestName(), buildSuggestRequest.getIndexName()))
+                        .augmentDescription(e.getMessage())
+                        .asRuntimeException());
+            }
+        }
     }
 
     static class ReplicationServerImpl extends ReplicationServerGrpc.ReplicationServerImplBase {

--- a/src/main/java/org/apache/platypus/server/luceneserver/BuildSuggestHandler.java
+++ b/src/main/java/org/apache/platypus/server/luceneserver/BuildSuggestHandler.java
@@ -1,0 +1,522 @@
+/*
+ *
+ *  *
+ *  *  Copyright 2019 Yelp Inc.
+ *  *
+ *  *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  *  you may not use this file except in compliance with the License.
+ *  *  You may obtain a copy of the License at
+ *  *       http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *  Unless required by applicable law or agreed to in writing, software
+ *  *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ *  *  either express or implied.
+ *  *  See the License for the specific language governing permissions and
+ *  *  limitations under the License.
+ *  *
+ *  *
+ *
+ *
+ */
+
+package org.apache.platypus.server.luceneserver;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonParser;
+import com.google.protobuf.InvalidProtocolBufferException;
+import com.google.protobuf.util.JsonFormat;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.store.IOContext;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.apache.lucene.analysis.tokenattributes.OffsetAttribute;
+import org.apache.lucene.expressions.Expression;
+import org.apache.lucene.expressions.js.JavascriptCompiler;
+import org.apache.lucene.facet.taxonomy.SearcherTaxonomyManager;
+import org.apache.lucene.search.suggest.DocumentDictionary;
+import org.apache.lucene.search.suggest.DocumentValueSourceDictionary;
+import org.apache.lucene.search.suggest.InputIterator;
+import org.apache.lucene.search.suggest.Lookup;
+import org.apache.lucene.search.suggest.analyzing.AnalyzingInfixSuggester;
+import org.apache.lucene.search.suggest.analyzing.AnalyzingSuggester;
+import org.apache.lucene.util.BytesRef;
+import org.apache.platypus.server.grpc.BuildSuggestRequest;
+import org.apache.platypus.server.grpc.BuildSuggestResponse;
+import org.apache.platypus.server.grpc.FuzzySuggester;
+import org.apache.platypus.server.grpc.OneHighlight;
+import org.apache.platypus.server.grpc.SearchRequest;
+import org.apache.platypus.server.grpc.SuggestLookupHighlight;
+import org.apache.platypus.server.grpc.SuggestNonLocalSource;
+import org.eclipse.jetty.server.Request;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Handles {@code buildSuggest}.
+ */
+public class BuildSuggestHandler implements Handler<BuildSuggestRequest, BuildSuggestResponse> {
+    Logger logger = LoggerFactory.getLogger(BuildSuggestHandler.class);
+    private final JsonParser jsonParser = new JsonParser();
+    private final Gson gson = new Gson();
+
+    /**
+     * Load all previously built suggesters.
+     */
+    public void load(IndexState indexState, JsonObject saveState) throws IOException {
+        ShardState shardState = indexState.getShard(0);
+        for (Map.Entry<String, JsonElement> ent : saveState.entrySet()) {
+            String suggestName = ent.getKey();
+            JsonObject buildSuggestRequestAsJsonObject = ent.getValue().getAsJsonObject();
+            String jsonStr = gson.toJson(buildSuggestRequestAsJsonObject);
+            BuildSuggestRequest.Builder buildSuggestRequestBuilder = BuildSuggestRequest.newBuilder();
+            try {
+                JsonFormat.parser().merge(jsonStr, buildSuggestRequestBuilder);
+            } catch (InvalidProtocolBufferException e) {
+                throw new RuntimeException(e);
+            }
+            BuildSuggestRequest buildSuggestRequest = buildSuggestRequestBuilder.build();
+            Lookup suggester = getSuggester(indexState, buildSuggestRequest);
+
+            if ((suggester instanceof AnalyzingInfixSuggester) == false) {
+                // nocommit store suggesters 1 dir up:
+                try (IndexInput in = shardState.origIndexDir.openInput("suggest." + suggestName, IOContext.DEFAULT)) {
+                    suggester.load(in);
+                }
+            }
+            indexState.addSuggest(suggestName, buildSuggestRequestAsJsonObject);
+        }
+    }
+
+    private Lookup getSuggester(IndexState indexState, BuildSuggestRequest buildSuggestRequest) throws IOException {
+        String suggestName = buildSuggestRequest.getSuggestName();
+
+        ShardState shardState = indexState.getShard(0);
+
+        Lookup oldSuggester = indexState.suggesters.get(suggestName);
+        if (oldSuggester != null && oldSuggester instanceof Closeable) {
+            ((Closeable) oldSuggester).close();
+            indexState.suggesters.remove(suggestName);
+        }
+
+        Analyzer indexAnalyzer;
+        Analyzer queryAnalyzer;
+        final Lookup suggester;
+
+        if (buildSuggestRequest.hasFuzzySuggester()) {
+            int options = 0;
+            FuzzySuggester fuzzySuggester = buildSuggestRequest.getFuzzySuggester();
+            if (fuzzySuggester.getAnalyzer() != null) {
+                indexAnalyzer = queryAnalyzer = RegisterFieldsHandler.getAnalyzer(indexState, null, "analyzer");
+            } else {
+                indexAnalyzer = RegisterFieldsHandler.getAnalyzer(indexState, null, "indexAnalyzer");
+                queryAnalyzer = RegisterFieldsHandler.getAnalyzer(indexState, null, "queryAnalyzer");
+            }
+            if (indexAnalyzer == null) {
+                throw new RuntimeException("analyzer analyzer or indexAnalyzer must be specified");
+            }
+            if (queryAnalyzer == null) {
+                throw new RuntimeException("analyzer analyzer or queryAnalyzer must be specified");
+            }
+
+            if (fuzzySuggester.getPreserveSep()) {
+                options |= AnalyzingSuggester.PRESERVE_SEP;
+            }
+            if (fuzzySuggester.getExactFirst()) {
+                options |= AnalyzingSuggester.EXACT_FIRST;
+            }
+            //default values
+            int maxSurfaceFormsPerAnalyzedForm = fuzzySuggester.getMaxSurfaceFormsPerAnalyzedForm() == 0 ? 156 : fuzzySuggester.getMaxSurfaceFormsPerAnalyzedForm();
+            int maxGraphExpansions = fuzzySuggester.getMaxGraphExpansions() == 0 ? -1 : fuzzySuggester.getMaxGraphExpansions();
+            int minFuzzyLength = fuzzySuggester.getMinFuzzyLength() == 0 ? org.apache.lucene.search.suggest.analyzing.FuzzySuggester.DEFAULT_MIN_FUZZY_LENGTH : fuzzySuggester.getMinFuzzyLength();
+            int nonFuzzyPrefix = fuzzySuggester.getNonFuzzyPrefix() == 0 ? org.apache.lucene.search.suggest.analyzing.FuzzySuggester.DEFAULT_NON_FUZZY_PREFIX : fuzzySuggester.getNonFuzzyPrefix();
+            int maxEdits = fuzzySuggester.getMaxEdits() == 0 ? org.apache.lucene.search.suggest.analyzing.FuzzySuggester.DEFAULT_MAX_EDITS : fuzzySuggester.getMaxEdits();
+
+            suggester = new org.apache.lucene.search.suggest.analyzing.FuzzySuggester(shardState.origIndexDir, "FuzzySuggester",
+                    indexAnalyzer, queryAnalyzer,
+                    options,
+                    maxSurfaceFormsPerAnalyzedForm,
+                    maxGraphExpansions,
+                    true,
+                    maxEdits,
+                    fuzzySuggester.getTranspositions(),
+                    nonFuzzyPrefix,
+                    minFuzzyLength,
+                    fuzzySuggester.getUnicodeAware());
+        } else if (buildSuggestRequest.hasAnalyzingSuggester()) {
+            int options = 0;
+            org.apache.platypus.server.grpc.AnalyzingSuggester analyzingSuggester = buildSuggestRequest.getAnalyzingSuggester();
+            if (analyzingSuggester.getAnalyzer() != null) {
+                indexAnalyzer = queryAnalyzer = RegisterFieldsHandler.getAnalyzer(indexState, null, "analyzer");
+            } else {
+                indexAnalyzer = RegisterFieldsHandler.getAnalyzer(indexState, null, "indexAnalyzer");
+                queryAnalyzer = RegisterFieldsHandler.getAnalyzer(indexState, null, "queryAnalyzer");
+            }
+            if (indexAnalyzer == null) {
+                throw new RuntimeException("analyzer analyzer or indexAnalyzer must be specified");
+            }
+            if (queryAnalyzer == null) {
+                throw new RuntimeException("analyzer analyzer or queryAnalyzer must be specified");
+            }
+
+            if (analyzingSuggester.getPreserveSep()) {
+                options |= AnalyzingSuggester.PRESERVE_SEP;
+            }
+            if (analyzingSuggester.getExactFirst()) {
+                options |= AnalyzingSuggester.EXACT_FIRST;
+            }
+            //default values
+            int maxSurfaceFormsPerAnalyzedForm = analyzingSuggester.getMaxSurfaceFormsPerAnalyzedForm() == 0 ? 256 : analyzingSuggester.getMaxSurfaceFormsPerAnalyzedForm();
+            int maxGraphExpansions = analyzingSuggester.getMaxGraphExpansions() == 0 ? -1 : analyzingSuggester.getMaxGraphExpansions();
+            suggester = new AnalyzingSuggester(shardState.origIndexDir, "AnalyzingSuggester",
+                    indexAnalyzer, queryAnalyzer, options,
+                    maxSurfaceFormsPerAnalyzedForm,
+                    maxGraphExpansions, true);
+        } else if (buildSuggestRequest.hasInfixSuggester()) {
+            if (buildSuggestRequest.getInfixSuggester().getAnalyzer() != null) {
+                indexAnalyzer = queryAnalyzer = RegisterFieldsHandler.getAnalyzer(indexState, null, "analyzer");
+            } else {
+                indexAnalyzer = RegisterFieldsHandler.getAnalyzer(indexState, null, "indexAnalyzer");
+                queryAnalyzer = RegisterFieldsHandler.getAnalyzer(indexState, null, "queryAnalyzer");
+            }
+            if (indexAnalyzer == null) {
+                throw new RuntimeException("analyzer analyzer or indexAnalyzer must be specified");
+            }
+            if (queryAnalyzer == null) {
+                throw new RuntimeException("analyzer analyzer or queryAnalyzer must be specified");
+            }
+
+            suggester = new AnalyzingInfixSuggester(indexState.df.open(indexState.rootDir.resolve("suggest." + suggestName + ".infix")),
+                    indexAnalyzer,
+                    queryAnalyzer,
+                    AnalyzingInfixSuggester.DEFAULT_MIN_PREFIX_CHARS,
+                    true) {
+                @Override
+                protected Object highlight(String text, Set<String> matchedTokens, String prefixToken) throws IOException {
+
+                    // We override the entire highlight method, to
+                    // render directly to JSONArray instead of html
+                    // string:
+
+                    // nocommit push this fix (queryAnalyzer -> indexAnalyzer) back:
+                    TokenStream ts = indexAnalyzer.tokenStream("text", new StringReader(text));
+                    CharTermAttribute termAtt = ts.addAttribute(CharTermAttribute.class);
+                    OffsetAttribute offsetAtt = ts.addAttribute(OffsetAttribute.class);
+                    ts.reset();
+                    SuggestLookupHighlight.Builder suggestLookupHighlightBuilder = SuggestLookupHighlight.newBuilder();
+                    int upto = 0;
+                    while (ts.incrementToken()) {
+                        String token = termAtt.toString();
+                        int startOffset = offsetAtt.startOffset();
+                        int endOffset = offsetAtt.endOffset();
+                        if (upto < startOffset) {
+                            OneHighlight.Builder oneHighlightBuilder = OneHighlight.newBuilder();
+                            oneHighlightBuilder.setIsHit(false);
+                            oneHighlightBuilder.setText(text.substring(upto, startOffset));
+                            suggestLookupHighlightBuilder.addOneHighlight(oneHighlightBuilder);
+                            upto = startOffset;
+                        } else if (upto > startOffset) {
+                            continue;
+                        }
+
+                        if (matchedTokens.contains(token)) {
+                            // Token matches.
+                            OneHighlight.Builder oneHighlightBuilder = OneHighlight.newBuilder();
+                            oneHighlightBuilder.setIsHit(true);
+                            oneHighlightBuilder.setText(text.substring(startOffset, endOffset));
+                            suggestLookupHighlightBuilder.addOneHighlight(oneHighlightBuilder);
+                            upto = endOffset;
+                        } else if (prefixToken != null && token.startsWith(prefixToken)) {
+                            OneHighlight.Builder oneHighlightBuilder = OneHighlight.newBuilder();
+                            oneHighlightBuilder.setIsHit(true);
+                            oneHighlightBuilder.setText(text.substring(startOffset, startOffset + prefixToken.length()));
+                            suggestLookupHighlightBuilder.addOneHighlight(oneHighlightBuilder);
+                            if (prefixToken.length() < token.length()) {
+                                OneHighlight.Builder oneMoreHighlightBuilder = OneHighlight.newBuilder();
+                                oneMoreHighlightBuilder.setIsHit(false);
+                                oneMoreHighlightBuilder.setText(text.substring(startOffset + prefixToken.length(), startOffset + token.length()));
+                                suggestLookupHighlightBuilder.addOneHighlight(oneMoreHighlightBuilder);
+                            }
+                            upto = endOffset;
+                        }
+                    }
+                    ts.end();
+                    int endOffset = offsetAtt.endOffset();
+                    if (upto < endOffset) {
+                        OneHighlight.Builder oneHighlightBuilder = OneHighlight.newBuilder();
+                        oneHighlightBuilder.setIsHit(false);
+                        oneHighlightBuilder.setText(text.substring(upto));
+                        suggestLookupHighlightBuilder.addOneHighlight(oneHighlightBuilder);
+                    }
+                    ts.close();
+
+                    return suggestLookupHighlightBuilder.build();
+                }
+            };
+        } else {
+            throw new RuntimeException("Suggester provided must be one of AnalyzingSuggester, InfixSuggester, FuzzySuggester");
+        }
+
+        indexState.suggesters.put(suggestName, suggester);
+
+        return suggester;
+    }
+
+
+    /**
+     * Used to return highlighted result; see {@link
+     * Lookup.LookupResult#highlightKey}
+     */
+    public static final class LookupHighlightFragment {
+        /**
+         * Portion of text for this fragment.
+         */
+        public final String text;
+
+        /**
+         * True if this text matched a part of the user's
+         * query.
+         */
+        public final boolean isHit;
+
+        /**
+         * Sole constructor.
+         */
+        public LookupHighlightFragment(String text, boolean isHit) {
+            this.text = text;
+            this.isHit = isHit;
+        }
+
+        @Override
+        public String toString() {
+            return "LookupHighlightFragment(text=" + text + " isHit=" + isHit + ")";
+        }
+    }
+
+    /**
+     * Wraps another {@link InputIterator} and counts how
+     * many suggestions were seen.
+     */
+    private static class CountingInputIterator implements InputIterator {
+
+        private final InputIterator other;
+        private int count;
+
+        public CountingInputIterator(InputIterator other) {
+            this.other = other;
+        }
+
+        @Override
+        public boolean hasContexts() {
+            return other.hasContexts();
+        }
+
+        @Override
+        public Set<BytesRef> contexts() {
+            return other.contexts();
+        }
+
+        @Override
+        public long weight() {
+            return other.weight();
+        }
+
+        @Override
+        public BytesRef next() throws IOException {
+            BytesRef result = other.next();
+            if (result != null) {
+                count++;
+            }
+
+            return result;
+        }
+
+        @Override
+        public BytesRef payload() {
+            return other.payload();
+        }
+
+        @Override
+        public boolean hasPayloads() {
+            return other.hasPayloads();
+        }
+
+        public int getCount() {
+            return count;
+        }
+    }
+
+    @Override
+    public BuildSuggestResponse handle(IndexState indexState, BuildSuggestRequest buildSuggestRequest) throws HandlerException {
+
+        ShardState shardState = indexState.getShard(0);
+        final JsonObject buildSuggestRequestAsJsonObject;
+        try {
+            //convert Proto object to Json String
+            String jsonOrig = JsonFormat.printer().print(buildSuggestRequest);
+            buildSuggestRequestAsJsonObject = jsonParser.parse(jsonOrig).getAsJsonObject();
+        } catch (InvalidProtocolBufferException e) {
+            throw new RuntimeException(e);
+        }
+
+        final String suggestName = buildSuggestRequest.getSuggestName();
+        if (!IndexState.isSimpleName(suggestName)) {
+            throw new RuntimeException("suggestName: invalid suggestName \"" + suggestName + "\": must be [a-zA-Z_][a-zA-Z0-9]*");
+        }
+
+        final Lookup suggester;
+        try {
+            suggester = getSuggester(indexState, buildSuggestRequest);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        InputIterator iterator = null;
+        final SearcherTaxonomyManager.SearcherAndTaxonomy searcher;
+
+        if (buildSuggestRequest.hasLocalSource()) {
+            final File localFile = new File(buildSuggestRequest.getLocalSource().getLocalFile());
+            if (!localFile.exists()) {
+                throw new RuntimeException(String.format("localFile %s does not exist", buildSuggestRequest.getLocalSource().getLocalFile()));
+            }
+            if (!localFile.canRead()) {
+                throw new RuntimeException(String.format("localFile %s cannot read file", buildSuggestRequest.getLocalSource().getLocalFile()));
+            }
+            boolean hasContexts = buildSuggestRequest.getLocalSource().getHasContexts();
+            searcher = null;
+            // Pull suggestions from local file:
+            try {
+                iterator = new FromFileTermFreqIterator(localFile, hasContexts);
+            } catch (IOException ioe) {
+                throw new RuntimeException("localFile cannot open file", ioe);
+            }
+        } else {
+            indexState.verifyStarted();
+            SuggestNonLocalSource nonLocalSource = buildSuggestRequest.getNonLocalSource();
+            // Pull suggestions from stored docs:
+            SuggestNonLocalSource.WeightCase weightCase = buildSuggestRequest.getNonLocalSource().getWeightCase();
+            SuggestNonLocalSource.SearcherCase searcherCase = buildSuggestRequest.getNonLocalSource().getSearcherCase();
+            SearchRequest.Builder searchRequestBuilder = SearchRequest.newBuilder();
+            if (searcherCase.equals(SuggestNonLocalSource.SearcherCase.INDEXGEN)) {
+                searchRequestBuilder.setIndexGen(buildSuggestRequest.getNonLocalSource().getIndexGen());
+            } else if (searcherCase.equals(SuggestNonLocalSource.SearcherCase.VERSION)) {
+                searchRequestBuilder.setVersion(buildSuggestRequest.getNonLocalSource().getVersion());
+            } else if (searcherCase.equals(SuggestNonLocalSource.SearcherCase.SNAPSHOT)) {
+                searchRequestBuilder.setSnapshot(buildSuggestRequest.getNonLocalSource().getSnapshot());
+            } else {
+                logger.info("using current searcher version to build suggest index");
+            }
+
+            try {
+                if (!searcherCase.equals(SuggestNonLocalSource.SearcherCase.SEARCHER_NOT_SET)) {
+                    // Specific searcher version:
+                    searcher = SearchHandler.getSearcherAndTaxonomy(searchRequestBuilder.build(), shardState, null);
+                } else {
+                    searcher = shardState.acquire();
+                }
+            } catch (IOException | InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+
+            String suggestField = nonLocalSource.getSuggestField();
+
+            String payloadField = nonLocalSource.getPayloadField();
+
+            DocumentDictionary dict;
+
+            if (weightCase.equals(SuggestNonLocalSource.WeightCase.WEIGHTFIELD)) {
+                // Weight is a field
+                String weightField = nonLocalSource.getWeightField();
+                dict = new DocumentDictionary(searcher.searcher.getIndexReader(),
+                        suggestField,
+                        weightField,
+                        payloadField);
+            } else {
+                // Weight is an expression; add bindings for all
+                // numeric DV fields:
+                Expression expr;
+                try {
+                    expr = JavascriptCompiler.compile(nonLocalSource.getWeightExpression());
+                } catch (Exception e) {
+                    throw new RuntimeException("weightExpression: expression does not compile", e);
+                }
+
+                dict = new DocumentValueSourceDictionary(searcher.searcher.getIndexReader(),
+                        suggestField,
+                        expr.getDoubleValuesSource(indexState.exprBindings).toLongValuesSource(),
+                        payloadField);
+            }
+
+            try {
+                iterator = dict.getEntryIterator();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        // nocommit return error if suggester already exists?
+        // nocommit need a DeleteSuggestHandler
+        try {
+            return getBuildSuggestResponse(suggester, indexState, shardState, iterator,
+                    suggestName, buildSuggestRequestAsJsonObject, searcher);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private BuildSuggestResponse getBuildSuggestResponse(Lookup suggester, IndexState indexState, ShardState shardState,
+                                                         InputIterator iterator, String suggestName, JsonObject buildSuggestRequestAsJsonObject, SearcherTaxonomyManager.SearcherAndTaxonomy searcher) throws IOException {
+        final InputIterator iterator0 = iterator;
+        try {
+            suggester.build(iterator0);
+        } catch (IOException e) {
+            logger.info("error while building suggest index");
+            throw new RuntimeException(e);
+        } finally {
+            if (iterator0 instanceof Closeable) {
+                ((Closeable) iterator0).close();
+            }
+            if (searcher != null) {
+                shardState.release(searcher);
+            }
+        }
+
+        boolean success = false;
+        try (IndexOutput out = shardState.origIndexDir.createOutput("suggest." + suggestName, IOContext.DEFAULT)) {
+            // nocommit look @ return value
+            suggester.store(out);
+            success = true;
+        } finally {
+            if (success == false) {
+                shardState.origIndexDir.deleteFile("suggest." + suggestName);
+            }
+        }
+
+        indexState.addSuggest(suggestName, buildSuggestRequestAsJsonObject);
+
+        BuildSuggestResponse.Builder buildSuggestResponseBuilder = BuildSuggestResponse.newBuilder();
+        if (suggester instanceof AnalyzingSuggester) {
+            buildSuggestResponseBuilder.setSizeInBytes(((AnalyzingSuggester) suggester).ramBytesUsed());
+        }
+        if (suggester instanceof AnalyzingInfixSuggester) {
+            ((AnalyzingInfixSuggester) suggester).commit();
+        }
+
+        buildSuggestResponseBuilder.setCount(suggester.getCount());
+        return buildSuggestResponseBuilder.build();
+
+    }
+
+}

--- a/src/main/java/org/apache/platypus/server/luceneserver/FromFileTermFreqIterator.java
+++ b/src/main/java/org/apache/platypus/server/luceneserver/FromFileTermFreqIterator.java
@@ -1,0 +1,147 @@
+/*
+ *
+ *  *
+ *  *  Copyright 2019 Yelp Inc.
+ *  *
+ *  *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  *  you may not use this file except in compliance with the License.
+ *  *  You may obtain a copy of the License at
+ *  *       http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *  Unless required by applicable law or agreed to in writing, software
+ *  *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ *  *  either express or implied.
+ *  *  See the License for the specific language governing permissions and
+ *  *  limitations under the License.
+ *  *
+ *  *
+ *
+ *
+ */
+
+package org.apache.platypus.server.luceneserver;
+
+import java.io.BufferedReader;
+import java.io.Closeable;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.apache.lucene.search.suggest.InputIterator;
+import org.apache.lucene.util.BytesRef;
+
+/**
+ * An {@link InputIterator} that pulls from a line file,
+ * using U+001f to join the suggestion, weight and payload.
+ */
+public class FromFileTermFreqIterator implements InputIterator, Closeable {
+    private final BufferedReader reader;
+    private long weight;
+    private int lineCount;
+    final boolean hasContexts;
+
+    /**
+     * How many suggestions were found.
+     */
+    public int suggestCount;
+
+    private BytesRef extra;
+    private final Set<BytesRef> contexts = new HashSet<>();
+
+    /**
+     * Sole constructor.
+     */
+    public FromFileTermFreqIterator(File sourceFile, boolean hasContexts) throws IOException {
+        reader = new BufferedReader(new InputStreamReader(new FileInputStream(sourceFile), "UTF-8"), 65536);
+        this.hasContexts = hasContexts;
+    }
+
+    @Override
+    public boolean hasContexts() {
+        return hasContexts;
+    }
+
+    @Override
+    public Set<BytesRef> contexts() {
+        return contexts;
+    }
+
+    @Override
+    public boolean hasPayloads() {
+        return true;
+    }
+
+    @Override
+    public BytesRef next() {
+        while (true) {
+            String line;
+            try {
+                line = reader.readLine();
+            } catch (IOException ioe) {
+                throw new RuntimeException("readLine failed", ioe);
+            }
+            if (line == null) {
+                return null;
+            }
+            lineCount++;
+            line = line.trim();
+            if (line.length() == 0 || line.charAt(0) == '#') {
+                continue;
+            }
+            int spot = line.indexOf('\u001f');
+            if (spot == -1) {
+                throw new RuntimeException("line " + lineCount + " is malformed");
+            }
+            weight = Long.parseLong(line.substring(0, spot));
+            suggestCount++;
+            int spot2 = line.indexOf('\u001f', spot + 1);
+            if (spot2 == -1) {
+                throw new RuntimeException("line " + lineCount + " is malformed");
+            }
+            BytesRef text = new BytesRef(line.substring(spot + 1, spot2));
+
+            int spot3 = line.indexOf('\u001f', spot2 + 1);
+            if (spot3 == -1) {
+                extra = new BytesRef(line.substring(spot2 + 1));
+            } else {
+                extra = new BytesRef(line.substring(spot2 + 1, spot3));
+
+                contexts.clear();
+
+                int upto = spot3 + 1;
+                while (true) {
+                    int nextUpto = line.indexOf('\u001f', upto);
+                    if (nextUpto == -1) {
+                        contexts.add(new BytesRef(line.substring(upto)));
+                        break;
+                    } else {
+                        contexts.add(new BytesRef(line.substring(upto, nextUpto)));
+                        upto = nextUpto + 1;
+                    }
+                }
+                //System.out.println("CONTEXTS: " + text.utf8ToString() + " -> " + contexts);
+            }
+
+            return text;
+        }
+    }
+
+    @Override
+    public BytesRef payload() {
+        return extra;
+    }
+
+    @Override
+    public long weight() {
+        return weight;
+    }
+
+    @Override
+    public void close() throws IOException {
+        reader.close();
+    }
+}

--- a/src/main/java/org/apache/platypus/server/luceneserver/ShardState.java
+++ b/src/main/java/org/apache/platypus/server/luceneserver/ShardState.java
@@ -274,6 +274,14 @@ public class ShardState implements Closeable {
         return nrtReplicaNode != null;
     }
 
+    public void waitForGeneration(long gen) throws InterruptedException, IOException {
+        if (nrtPrimaryNode != null) {
+            reopenThreadPrimary.waitForGeneration(gen);
+        } else {
+            reopenThread.waitForGeneration(gen);
+        }
+    }
+
 
     public static class HostAndPort {
         public final InetAddress host;

--- a/src/main/java/org/apache/platypus/server/luceneserver/SuggestLookupHandler.java
+++ b/src/main/java/org/apache/platypus/server/luceneserver/SuggestLookupHandler.java
@@ -1,0 +1,88 @@
+/*
+ *
+ *  *
+ *  *  Copyright 2019 Yelp Inc.
+ *  *
+ *  *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  *  you may not use this file except in compliance with the License.
+ *  *  You may obtain a copy of the License at
+ *  *       http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *  Unless required by applicable law or agreed to in writing, software
+ *  *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ *  *  either express or implied.
+ *  *  See the License for the specific language governing permissions and
+ *  *  limitations under the License.
+ *  *
+ *  *
+ *
+ *
+ */
+
+package org.apache.platypus.server.luceneserver;
+
+import org.apache.lucene.search.suggest.Lookup;
+import org.apache.lucene.search.suggest.analyzing.AnalyzingInfixSuggester;
+import org.apache.lucene.util.BytesRef;
+import org.apache.platypus.server.grpc.OneSuggestLookupResponse;
+import org.apache.platypus.server.grpc.SuggestLookupHighlight;
+import org.apache.platypus.server.grpc.SuggestLookupRequest;
+import org.apache.platypus.server.grpc.SuggestLookupResponse;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public class SuggestLookupHandler implements Handler<SuggestLookupRequest, SuggestLookupResponse> {
+    @Override
+    public SuggestLookupResponse handle(IndexState indexState, SuggestLookupRequest suggestLookupRequest) throws HandlerException {
+        String suggestName = suggestLookupRequest.getSuggestName();
+        final Lookup lookup = indexState.suggesters.get(suggestName);
+        if (lookup == null) {
+            throw new RuntimeException("suggestName: this suggester (\"" + suggestName + "\") was not yet built; valid suggestNames: " + indexState.suggesters.keySet());
+        }
+        final String text = suggestLookupRequest.getText();
+        final int count = suggestLookupRequest.getCount() == 0 ? 5 : suggestLookupRequest.getCount();
+        final boolean allTermsRequired = suggestLookupRequest.getAllTermsRequired();
+        final boolean highlight = suggestLookupRequest.getHighlight();
+
+        final Set<BytesRef> contexts;
+        if (!suggestLookupRequest.getContextsList().isEmpty()) {
+            contexts = new HashSet<>();
+            for (String each : suggestLookupRequest.getContextsList()) {
+                contexts.add(new BytesRef(each));
+            }
+        } else {
+            contexts = null;
+        }
+
+        List<Lookup.LookupResult> results;
+        try {
+            if (lookup instanceof AnalyzingInfixSuggester) {
+                results = ((AnalyzingInfixSuggester) lookup).lookup(text, contexts, count, allTermsRequired, highlight);
+            } else {
+                results = lookup.lookup(text, contexts, false, count);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        SuggestLookupResponse.Builder suggestLookupResponseBuilder = SuggestLookupResponse.newBuilder();
+        for (Lookup.LookupResult result : results) {
+            OneSuggestLookupResponse.Builder oneSuggestLookupResponseBuilder = OneSuggestLookupResponse.newBuilder();
+            if (result.highlightKey != null) {
+                oneSuggestLookupResponseBuilder.setSuggestLookupHighlight((SuggestLookupHighlight) result.highlightKey);
+            } else {
+                oneSuggestLookupResponseBuilder.setKey(result.key.toString());
+            }
+            oneSuggestLookupResponseBuilder.setWeight(result.value);
+            if (result.payload != null) {
+                oneSuggestLookupResponseBuilder.setPayload(result.payload.utf8ToString());
+            }
+            suggestLookupResponseBuilder.addResults(oneSuggestLookupResponseBuilder);
+        }
+        return suggestLookupResponseBuilder.build();
+    }
+}

--- a/src/main/java/org/apache/platypus/server/luceneserver/UpdateSuggestHandler.java
+++ b/src/main/java/org/apache/platypus/server/luceneserver/UpdateSuggestHandler.java
@@ -1,0 +1,86 @@
+/*
+ *
+ *  *
+ *  *  Copyright 2019 Yelp Inc.
+ *  *
+ *  *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  *  you may not use this file except in compliance with the License.
+ *  *  You may obtain a copy of the License at
+ *  *       http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *  Unless required by applicable law or agreed to in writing, software
+ *  *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ *  *  either express or implied.
+ *  *  See the License for the specific language governing permissions and
+ *  *  limitations under the License.
+ *  *
+ *  *
+ *
+ *
+ */
+
+package org.apache.platypus.server.luceneserver;
+
+import org.apache.lucene.search.suggest.InputIterator;
+import org.apache.lucene.search.suggest.Lookup;
+import org.apache.lucene.search.suggest.analyzing.AnalyzingInfixSuggester;
+import org.apache.lucene.util.BytesRef;
+import org.apache.platypus.server.grpc.BuildSuggestRequest;
+import org.apache.platypus.server.grpc.BuildSuggestResponse;
+import org.apache.platypus.server.grpc.SuggestLocalSource;
+
+import java.io.File;
+import java.io.IOException;
+
+/* Updates existing suggestions, if the suggester supports near-real-time changes. */
+public class UpdateSuggestHandler implements Handler<BuildSuggestRequest, BuildSuggestResponse> {
+    @Override
+    public BuildSuggestResponse handle(IndexState indexState, BuildSuggestRequest buildSuggestRequest) throws HandlerException {
+        final String suggestName = buildSuggestRequest.getSuggestName();
+        Lookup lookup = indexState.suggesters.get(suggestName);
+        if (lookup == null) {
+            throw new RuntimeException("suggestName: this suggester (\"" + suggestName + "\") was not yet built; valid suggestNames: " + indexState.suggesters.keySet());
+        }
+        if ((lookup instanceof AnalyzingInfixSuggester) == false) {
+            throw new UnsupportedOperationException("suggestName: can only update AnalyzingInfixSuggester; got " + lookup);
+        }
+
+        if (buildSuggestRequest.hasNonLocalSource()) {
+            throw new UnsupportedOperationException("Does not yet support pulling from index/expressions, like BuildSuggest");
+        }
+        if (!buildSuggestRequest.hasLocalSource()) {
+            throw new UnsupportedOperationException("Only supports pulling suggestions from local file");
+        }
+
+        final AnalyzingInfixSuggester lookup2 = (AnalyzingInfixSuggester) lookup;
+        SuggestLocalSource localSource = buildSuggestRequest.getLocalSource();
+        final File localFile = new File(localSource.getLocalFile());
+        final boolean hasContexts = localSource.getHasContexts();
+
+        try {
+            return updateSuggestions(localFile, hasContexts, lookup2);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private BuildSuggestResponse updateSuggestions(File localFile, boolean hasContexts, AnalyzingInfixSuggester lookup) throws IOException {
+        InputIterator iterator = new FromFileTermFreqIterator(localFile, hasContexts);
+        boolean hasPayloads = iterator.hasPayloads();
+        int count = 0;
+        while (true) {
+            BytesRef term = iterator.next();
+            if (term == null) {
+                break;
+            }
+            lookup.update(term, iterator.hasContexts() ? iterator.contexts() : null, iterator.weight(), hasPayloads ? iterator.payload() : null);
+            count++;
+        }
+        lookup.refresh();
+
+        return BuildSuggestResponse.newBuilder()
+                .setCount(count)
+                .build();
+    }
+}

--- a/src/main/proto/luceneserver.proto
+++ b/src/main/proto/luceneserver.proto
@@ -56,11 +56,15 @@ service LuceneServer {
     /* Delete index */
     rpc deleteIndex (DeleteIndexRequest) returns (DeleteIndexResponse) {
     }
-
     /* healthcheck */
     rpc status (HealthCheckRequest) returns (HealthCheckResponse) {
     }
-
+    /* Builds a new auto-suggester, loading suggestions via the provided local file path.*/
+    rpc buildSuggest (BuildSuggestRequest) returns (BuildSuggestResponse) {
+    }
+    /* Perform an auto-suggest lookup.*/
+    rpc suggestLookup (SuggestLookupRequest) returns (SuggestLookupResponse) {
+    }
 }
 
 //The ReplicationServer service definition.
@@ -89,6 +93,7 @@ service ReplicationServer {
     /** Invoked externally to replica, to get the current Searcher version on replica. Typically used to check i */
     rpc getCurrentSearcherVersion (IndexName) returns (SearcherVersion) {
     }
+
 
 }
 
@@ -412,6 +417,123 @@ message DummyResponse {
 message StopIndexRequest {
     string indexName = 1; //index name to stop
 }
+
+message BuildSuggestRequest {
+    string indexName = 1; //index name
+    oneof Suggester {
+        //A suggester that matches terms anywhere in the input text, not just as a prefix. (see @lucene:org:server.InfixSuggester)
+        InfixSuggester infixSuggester = 2;
+        /* Suggester that first analyzes the surface form, adds the analyzed form to a weighted FST, and
+        then does the same thing at lookup time (see @lucene:suggest:org.apache.lucene.search.suggest.analyzing.AnalyzingSuggester*/
+        AnalyzingSuggester analyzingSuggester = 3;
+        /* Implements a fuzzy AnalyzingSuggester (see @lucene:suggest:org.apache.lucene.search.suggest.analyzing.FuzzySuggester*/
+        FuzzySuggester fuzzySuggester = 4;
+    }
+    oneof Source {
+        SuggestLocalSource localSource = 5;
+        SuggestNonLocalSource nonLocalSource = 6;
+    }
+    string suggestName = 7; //Unique name for this suggest build.
+}
+
+message BuildSuggestResponse {
+    int64 sizeInBytes = 1; //size in bytes in RAM if using AnalyzingSuggester
+    int64 count = 2; //total number of suggester entries
+}
+
+message SuggestLookupRequest {
+    string indexName = 1; //Index name
+    string suggestName = 2; //Which suggester to use
+    string text = 3; //Text to suggest from
+    bool highlight = 4; //True if the suggestions should be highlighted (currently only works with AnalyzingInfixSuggester)
+    bool allTermsRequired = 5; //If true then all terms must be found (this only applies to InfixSuggester currently)
+    repeated string contexts = 6; //Which contexts to filter by
+    int32 count = 7; //How many suggestions to return, default = 5
+}
+
+message SuggestLookupResponse {
+    repeated OneSuggestLookupResponse results = 1; //SuggestLookup results as an array
+}
+
+message OneSuggestLookupResponse {
+    oneof HighlightKey {
+        /* Expert: custom Object to hold the result of a highlighted suggestion (currently only works with AnalyzingInfixSuggester) */
+        SuggestLookupHighlight suggestLookupHighlight = 1;
+        /* the key's text */
+        string key = 2;
+    }
+    int64 weight = 3; //the key's weight
+    string payload = 4; //the key's payload (null if not present)
+}
+
+message SuggestLookupHighlight {
+    repeated OneHighlight oneHighlight = 1;
+}
+
+message OneHighlight {
+    bool isHit = 1;
+    string text = 2;
+}
+
+message SuggestLocalSource {
+    /* Local file (to the server) to read suggestions + weights from; format is weight U+001F suggestion U+001F payload,
+    one per line, with suggestion UTF-8 encoded. If this option is used then searcher, suggestField,
+    weightField/Expression, payloadField should not be specified.*/
+    string localFile = 1;
+    bool hasContexts = 2; //True if this file provides per-suggestion contexts.
+}
+
+message SuggestNonLocalSource {
+    /* Specific searcher version to use for pull suggestions to build.  There are three different ways to specify a searcher version.*/
+    oneof Searcher {
+        int64 indexGen = 1; //Search a generation previously returned by an indexing operation such as #addDocument.  Use this to search a non-committed (near-real-time) view of the index.
+        int64 version = 2; //Search a specific searcher version.  This is typically used by follow-on searches (e.g., user clicks next page, drills down, or changes sort, etc.) to get the same searcher used by the original search.
+        string snapshot = 3; //Search a snapshot previously created with #createSnapshot
+    }
+    string suggestField = 4; //Field (from stored documents) containing the suggestion text
+    oneof Weight {
+        string weightField = 5; //Numeric field (from stored documents) containing the weight
+        string weightExpression = 6; //Alternative to weightField, an expression that's evaluated to the weight. Note that any fields referenced in the expression must have been indexed with sort=true
+
+    }
+    string payloadField = 7; //Optional binary or string field (from stored documents) containing the payload
+}
+
+/* A suggester that matches terms anywhere in the input text, not just as a prefix. (see @lucene:org:server.InfixSuggester)*/
+message InfixSuggester {
+    string analyzer = 1; //Index and query analyzer
+    string indexAnalyzer = 2; // Index Analyzer
+    string queryAnalyzer = 3; // Query Analyzer
+}
+
+/* Suggester that first analyzes the surface form, adds the analyzed form to a weighted FST, and
+then does the same thing at lookup time (see @lucene:suggest:org.apache.lucene.search.suggest.analyzing.AnalyzingSuggester*/
+message AnalyzingSuggester {
+    string analyzer = 1; //Index and query analyzer
+    string indexAnalyzer = 2; // Index Analyzer
+    string queryAnalyzer = 3; // Query Analyzer
+    int32 maxSurfaceFormsPerAnalyzedForm = 4; //Maximum number of surface forms to keep for a single analyzed form
+    int32 maxGraphExpansions = 5; //Maximum number of graph paths to expand from the analyzed from
+    bool preserveSep = 6; //True if token separators should be preserved when matching
+    bool exactFirst = 7; //True if the exact match should always be returned first regardless of score
+}
+
+/* Implements a fuzzy AnalyzingSuggester (see @lucene:suggest:org.apache.lucene.search.suggest.analyzing.FuzzySuggester*/
+message FuzzySuggester {
+    string analyzer = 1; //Index and query analyzer
+    string indexAnalyzer = 2; // Index Analyzer
+    string queryAnalyzer = 3; // Query Analyzer
+    int32 maxSurfaceFormsPerAnalyzedForm = 4; //Maximum number of surface forms to keep for a single analyzed form
+    int32 maxGraphExpansions = 5; //Maximum number of graph paths to expand from the analyzed from
+    bool preserveSep = 6; //True if token separators should be preserved when matching
+    bool exactFirst = 7; //True if the exact match should always be returned first regardless of score
+    int32 minFuzzyLength = 8; //Minimum key length before edits are allowed,
+    int32 nonFuzzyPrefix = 9; //Key prefix where edits are not allowed,
+    int32 maxEdits = 10; //Maximum number of edits for fuzzy suggestions
+    bool transpositions = 11; //Whether transpositions are allowed
+    bool unicodeAware = 12; //True if all edits are measured in unicode characters, not UTF-8 bytes
+}
+
 
 message AddReplicaRequest {
     int32 magicNumber = 1; //magic number send on all requests since these are meant for internal communication only

--- a/src/main/proto/luceneserver.proto
+++ b/src/main/proto/luceneserver.proto
@@ -65,6 +65,10 @@ service LuceneServer {
     /* Perform an auto-suggest lookup.*/
     rpc suggestLookup (SuggestLookupRequest) returns (SuggestLookupResponse) {
     }
+    /* Updates existing suggestions, if the suggester supports near-real-time changes. */
+    rpc updateSuggest (BuildSuggestRequest) returns (BuildSuggestResponse) {
+    }
+
 }
 
 //The ReplicationServer service definition.

--- a/src/test/java/org/apache/platypus/server/grpc/LuceneServerTest.java
+++ b/src/test/java/org/apache/platypus/server/grpc/LuceneServerTest.java
@@ -23,6 +23,7 @@ import java.nio.file.Paths;
 import java.util.*;
 import java.util.stream.Stream;
 
+import static org.apache.platypus.server.grpc.GrpcServer.rmDir;
 import static org.junit.Assert.*;
 
 @RunWith(JUnit4.class)
@@ -278,27 +279,6 @@ public class LuceneServerTest {
         Collections.sort(actualValues);
         assertEquals(expectedValues, actualValues);
     }
-
-    //TODO fix server to not need to use specific named directories?
-    public static void rmDir(Path dir) throws IOException {
-        if (Files.exists(dir)) {
-            if (Files.isRegularFile(dir)) {
-                Files.delete(dir);
-            } else {
-                try (DirectoryStream<Path> stream = Files.newDirectoryStream(dir)) {
-                    for (Path path : stream) {
-                        if (Files.isDirectory(path)) {
-                            rmDir(path);
-                        } else {
-                            Files.delete(path);
-                        }
-                    }
-                }
-                Files.delete(dir);
-            }
-        }
-    }
-
 
     private Stream<AddDocumentRequest> getAddDocumentRequestStream() throws IOException {
         Path filePath = Paths.get("src", "test", "resources", "addDocs.csv");

--- a/src/test/java/org/apache/platypus/server/grpc/SuggestTest.java
+++ b/src/test/java/org/apache/platypus/server/grpc/SuggestTest.java
@@ -1,0 +1,141 @@
+/*
+ *
+ *  *
+ *  *  Copyright 2019 Yelp Inc.
+ *  *
+ *  *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  *  you may not use this file except in compliance with the License.
+ *  *  You may obtain a copy of the License at
+ *  *       http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *  Unless required by applicable law or agreed to in writing, software
+ *  *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ *  *  either express or implied.
+ *  *  See the License for the specific language governing permissions and
+ *  *  limitations under the License.
+ *  *
+ *  *
+ *
+ *
+ */
+
+package org.apache.platypus.server.grpc;
+
+import io.grpc.testing.GrpcCleanupRule;
+import org.apache.platypus.server.luceneserver.GlobalState;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.io.BufferedWriter;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+import static org.apache.platypus.server.grpc.GrpcServer.rmDir;
+import static org.junit.Assert.assertEquals;
+
+@RunWith(JUnit4.class)
+public class SuggestTest {
+    /**
+     * This rule manages automatic graceful shutdown for the registered servers and channels at the
+     * end of test.
+     */
+    @Rule
+    public final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
+    /**
+     * This rule ensure the temporary folder which maintains indexes are cleaned up after each test
+     */
+    @Rule
+    public final TemporaryFolder folder = new TemporaryFolder();
+
+    private GrpcServer grpcServer;
+    static Path tempFile;
+
+    @After
+    public void tearDown() throws IOException {
+        grpcServer.getGlobalState().close();
+        rmDir(Paths.get(grpcServer.getRootDirName()));
+        tempFile = null;
+    }
+
+    @Before
+    public void setUp() throws IOException {
+        String nodeName = "server1";
+        String rootDirName = "server1RootDirName1";
+        Path rootDir = folder.newFolder(rootDirName).toPath();
+        String testIndex = "test_index";
+        GlobalState globalState = new GlobalState(nodeName, rootDir, null, 9000, 9000);
+        grpcServer = new GrpcServer(grpcCleanup, folder, false, globalState, rootDirName, testIndex, globalState.getPort());
+        Path tempDir = folder.newFolder("TestSuggest").toPath();
+        tempFile = tempDir.resolve("suggest.in");
+    }
+
+    @Test
+    public void testInfixSuggest() throws Exception {
+        GrpcServer.TestServer testAddDocs = new GrpcServer.TestServer(grpcServer, true, Mode.STANDALONE);
+        Writer fstream = new OutputStreamWriter(new FileOutputStream(tempFile.toFile()), "UTF-8");
+        BufferedWriter out = new BufferedWriter(fstream);
+        out.write("15\u001flove lost\u001ffoobar\n");
+        out.close();
+
+        BuildSuggestRequest.Builder buildSuggestRequestBuilder = BuildSuggestRequest.newBuilder();
+        buildSuggestRequestBuilder.setSuggestName("suggest2");
+        buildSuggestRequestBuilder.setIndexName("test_index");
+        buildSuggestRequestBuilder.setInfixSuggester(InfixSuggester.newBuilder()
+                .setAnalyzer("default").build());
+        buildSuggestRequestBuilder.setLocalSource(SuggestLocalSource.newBuilder()
+                .setLocalFile(tempFile.toAbsolutePath().toString())
+                .setHasContexts(false).build());
+        BuildSuggestResponse response = grpcServer.getBlockingStub().buildSuggest(buildSuggestRequestBuilder.build());
+        assertEquals(1, response.getCount());
+
+        SuggestLookupRequest.Builder suggestLookupBuilder = SuggestLookupRequest.newBuilder();
+        suggestLookupBuilder.setText("lost");
+        suggestLookupBuilder.setSuggestName("suggest2");
+        suggestLookupBuilder.setIndexName("test_index");
+        suggestLookupBuilder.setHighlight(true);
+        SuggestLookupResponse suggestResponse = grpcServer.getBlockingStub().suggestLookup(suggestLookupBuilder.build());
+        List<OneSuggestLookupResponse> results = suggestResponse.getResultsList();
+        assertEquals(15, results.get(0).getWeight());
+        SuggestLookupHighlight suggestLookupHighLight = results.get(0).getSuggestLookupHighlight();
+        assertEquals(2, suggestLookupHighLight.getOneHighlightList().size());
+        assertEquals("love ", suggestLookupHighLight.getOneHighlight(0).getText());
+        assertEquals(false, suggestLookupHighLight.getOneHighlight(0).getIsHit());
+        assertEquals("lost", suggestLookupHighLight.getOneHighlight(1).getText());
+        assertEquals(true, suggestLookupHighLight.getOneHighlight(1).getIsHit());
+        assertEquals("foobar", results.get(0).getPayload());
+
+        suggestLookupBuilder = SuggestLookupRequest.newBuilder();
+        suggestLookupBuilder.setText("lo");
+        suggestLookupBuilder.setSuggestName("suggest2");
+        suggestLookupBuilder.setIndexName("test_index");
+        suggestLookupBuilder.setHighlight(true);
+        suggestResponse = grpcServer.getBlockingStub().suggestLookup(suggestLookupBuilder.build());
+        results = suggestResponse.getResultsList();
+        assertEquals(15, results.get(0).getWeight());
+        suggestLookupHighLight = results.get(0).getSuggestLookupHighlight();
+        assertEquals(5, suggestLookupHighLight.getOneHighlightList().size());
+        assertEquals("lo", suggestLookupHighLight.getOneHighlight(0).getText());
+        assertEquals(true, suggestLookupHighLight.getOneHighlight(0).getIsHit());
+        assertEquals("ve", suggestLookupHighLight.getOneHighlight(1).getText());
+        assertEquals(false, suggestLookupHighLight.getOneHighlight(1).getIsHit());
+        assertEquals(" ", suggestLookupHighLight.getOneHighlight(2).getText());
+        assertEquals(false, suggestLookupHighLight.getOneHighlight(2).getIsHit());
+        assertEquals("lo", suggestLookupHighLight.getOneHighlight(3).getText());
+        assertEquals(true, suggestLookupHighLight.getOneHighlight(3).getIsHit());
+        assertEquals("st", suggestLookupHighLight.getOneHighlight(4).getText());
+        assertEquals(false, suggestLookupHighLight.getOneHighlight(4).getIsHit());
+        assertEquals("foobar", results.get(0).getPayload());
+    }
+
+}

--- a/src/test/java/org/apache/platypus/server/grpc/SuggestTest.java
+++ b/src/test/java/org/apache/platypus/server/grpc/SuggestTest.java
@@ -46,6 +46,13 @@ import static org.junit.Assert.assertEquals;
 
 @RunWith(JUnit4.class)
 public class SuggestTest {
+
+    enum Suggester {
+        INFIX,
+        ANALYZING,
+        FUZZY
+    }
+
     /**
      * This rule manages automatic graceful shutdown for the registered servers and channels at the
      * end of test.
@@ -88,42 +95,49 @@ public class SuggestTest {
         out.write("15\u001flove lost\u001ffoobar\n");
         out.close();
 
-        BuildSuggestRequest.Builder buildSuggestRequestBuilder = BuildSuggestRequest.newBuilder();
-        buildSuggestRequestBuilder.setSuggestName("suggest2");
-        buildSuggestRequestBuilder.setIndexName("test_index");
-        buildSuggestRequestBuilder.setInfixSuggester(InfixSuggester.newBuilder()
-                .setAnalyzer("default").build());
-        buildSuggestRequestBuilder.setLocalSource(SuggestLocalSource.newBuilder()
-                .setLocalFile(tempFile.toAbsolutePath().toString())
-                .setHasContexts(false).build());
-        BuildSuggestResponse response = grpcServer.getBlockingStub().buildSuggest(buildSuggestRequestBuilder.build());
+        BuildSuggestResponse response = sendBuildSuggest("suggest2", false, false, Suggester.INFIX);
         assertEquals(1, response.getCount());
 
+        assertOneHighlightOnIndexLoveLost("lost", "suggest2", 15, "foobar");
+        assertMultipleHighlightsOnIndexLoveLost("lo", "suggest2", 15, "foobar");
+    }
+
+    private BuildSuggestResponse sendBuildSuggest(String suggestName, boolean hasContexts, boolean isUpdate, Suggester suggester) {
+        BuildSuggestRequest.Builder buildSuggestRequestBuilder = BuildSuggestRequest.newBuilder();
+        buildSuggestRequestBuilder.setSuggestName(suggestName);
+        buildSuggestRequestBuilder.setIndexName("test_index");
+        if (suggester.equals(Suggester.INFIX)) {
+            buildSuggestRequestBuilder.setInfixSuggester(InfixSuggester.newBuilder()
+                    .setAnalyzer("default").build());
+        } else if (suggester.equals(Suggester.ANALYZING)) {
+            buildSuggestRequestBuilder.setAnalyzingSuggester(AnalyzingSuggester.newBuilder()
+                    .setAnalyzer("default").build());
+        } else if (suggester.equals(Suggester.FUZZY)) {
+            buildSuggestRequestBuilder.setFuzzySuggester(FuzzySuggester.newBuilder()
+                    .setAnalyzer("default").build());
+        }
+        buildSuggestRequestBuilder.setLocalSource(SuggestLocalSource.newBuilder()
+                .setLocalFile(tempFile.toAbsolutePath().toString())
+                .setHasContexts(hasContexts).build());
+        BuildSuggestResponse response;
+        if (isUpdate) {
+            response = grpcServer.getBlockingStub().updateSuggest(buildSuggestRequestBuilder.build());
+        } else {
+            response = grpcServer.getBlockingStub().buildSuggest(buildSuggestRequestBuilder.build());
+        }
+        return response;
+    }
+
+    private void assertMultipleHighlightsOnIndexLoveLost(String text, String suggestName, long weight, String payload) {
         SuggestLookupRequest.Builder suggestLookupBuilder = SuggestLookupRequest.newBuilder();
-        suggestLookupBuilder.setText("lost");
-        suggestLookupBuilder.setSuggestName("suggest2");
+        suggestLookupBuilder.setText(text);
+        suggestLookupBuilder.setSuggestName(suggestName);
         suggestLookupBuilder.setIndexName("test_index");
         suggestLookupBuilder.setHighlight(true);
         SuggestLookupResponse suggestResponse = grpcServer.getBlockingStub().suggestLookup(suggestLookupBuilder.build());
         List<OneSuggestLookupResponse> results = suggestResponse.getResultsList();
-        assertEquals(15, results.get(0).getWeight());
+        assertEquals(weight, results.get(0).getWeight());
         SuggestLookupHighlight suggestLookupHighLight = results.get(0).getSuggestLookupHighlight();
-        assertEquals(2, suggestLookupHighLight.getOneHighlightList().size());
-        assertEquals("love ", suggestLookupHighLight.getOneHighlight(0).getText());
-        assertEquals(false, suggestLookupHighLight.getOneHighlight(0).getIsHit());
-        assertEquals("lost", suggestLookupHighLight.getOneHighlight(1).getText());
-        assertEquals(true, suggestLookupHighLight.getOneHighlight(1).getIsHit());
-        assertEquals("foobar", results.get(0).getPayload());
-
-        suggestLookupBuilder = SuggestLookupRequest.newBuilder();
-        suggestLookupBuilder.setText("lo");
-        suggestLookupBuilder.setSuggestName("suggest2");
-        suggestLookupBuilder.setIndexName("test_index");
-        suggestLookupBuilder.setHighlight(true);
-        suggestResponse = grpcServer.getBlockingStub().suggestLookup(suggestLookupBuilder.build());
-        results = suggestResponse.getResultsList();
-        assertEquals(15, results.get(0).getWeight());
-        suggestLookupHighLight = results.get(0).getSuggestLookupHighlight();
         assertEquals(5, suggestLookupHighLight.getOneHighlightList().size());
         assertEquals("lo", suggestLookupHighLight.getOneHighlight(0).getText());
         assertEquals(true, suggestLookupHighLight.getOneHighlight(0).getIsHit());
@@ -135,7 +149,256 @@ public class SuggestTest {
         assertEquals(true, suggestLookupHighLight.getOneHighlight(3).getIsHit());
         assertEquals("st", suggestLookupHighLight.getOneHighlight(4).getText());
         assertEquals(false, suggestLookupHighLight.getOneHighlight(4).getIsHit());
+        assertEquals(payload, results.get(0).getPayload());
+    }
+
+    private void assertOneHighlightOnIndexLoveLost(String text, String suggestName, long weight, String payload) {
+        SuggestLookupRequest.Builder suggestLookupBuilder = SuggestLookupRequest.newBuilder();
+        suggestLookupBuilder.setText(text);
+        suggestLookupBuilder.setSuggestName(suggestName);
+        suggestLookupBuilder.setIndexName("test_index");
+        suggestLookupBuilder.setHighlight(true);
+        SuggestLookupResponse suggestResponse = grpcServer.getBlockingStub().suggestLookup(suggestLookupBuilder.build());
+        List<OneSuggestLookupResponse> results = suggestResponse.getResultsList();
+        assertEquals(weight, results.get(0).getWeight());
+        SuggestLookupHighlight suggestLookupHighLight = results.get(0).getSuggestLookupHighlight();
+        assertEquals(2, suggestLookupHighLight.getOneHighlightList().size());
+        assertEquals("love ", suggestLookupHighLight.getOneHighlight(0).getText());
+        assertEquals(false, suggestLookupHighLight.getOneHighlight(0).getIsHit());
+        assertEquals("lost", suggestLookupHighLight.getOneHighlight(1).getText());
+        assertEquals(true, suggestLookupHighLight.getOneHighlight(1).getIsHit());
+        assertEquals(payload, results.get(0).getPayload());
+
+    }
+
+    @Test
+    public void testInfixSuggestNRT() throws Exception {
+        GrpcServer.TestServer testAddDocs = new GrpcServer.TestServer(grpcServer, true, Mode.STANDALONE);
+        Writer fstream = new OutputStreamWriter(new FileOutputStream(tempFile.toFile()), "UTF-8");
+        BufferedWriter out = new BufferedWriter(fstream);
+        out.write("15\u001flove lost\u001ffoobar\n");
+        out.close();
+
+        BuildSuggestResponse response = sendBuildSuggest("suggestnrt", false, false, Suggester.INFIX);
+        assertEquals(1, response.getCount());
+
+        assertOneHighlightOnIndexLoveLost("lost", "suggestnrt", 15, "foobar");
+        assertMultipleHighlightsOnIndexLoveLost("lo", "suggestnrt", 15, "foobar");
+
+        // Now update the suggestions:
+        fstream = new OutputStreamWriter(new FileOutputStream(tempFile.toFile()), "UTF-8");
+        out = new BufferedWriter(fstream);
+        out.write("10\u001flove lost\u001ffoobaz\n");
+        out.write("20\u001flove found\u001ffooboo\n");
+        out.close();
+
+        response = sendBuildSuggest("suggestnrt", false, true, Suggester.INFIX);
+        assertEquals(2, response.getCount());
+
+        assertOneHighlightOnIndexLoveLost("lost", "suggestnrt", 10, "foobaz");
+
+        SuggestLookupRequest.Builder suggestLookupBuilder = SuggestLookupRequest.newBuilder();
+        suggestLookupBuilder.setText("lo");
+        suggestLookupBuilder.setSuggestName("suggestnrt");
+        suggestLookupBuilder.setIndexName("test_index");
+        suggestLookupBuilder.setHighlight(true);
+        SuggestLookupResponse suggestResponse = grpcServer.getBlockingStub().suggestLookup(suggestLookupBuilder.build());
+        List<OneSuggestLookupResponse> results = suggestResponse.getResultsList();
+        assertEquals(20, results.get(0).getWeight());
+        assertEquals("fooboo", results.get(0).getPayload());
+
+        SuggestLookupHighlight suggestLookupHighLight = results.get(0).getSuggestLookupHighlight();
+        SuggestLookupHighlight expected = SuggestLookupHighlight.newBuilder()
+                .addOneHighlight(OneHighlight.newBuilder().setText("lo").setIsHit(true).build())
+                .addOneHighlight(OneHighlight.newBuilder().setText("ve").setIsHit(false).build())
+                .addOneHighlight(OneHighlight.newBuilder().setText(" ").setIsHit(false).build())
+                .addOneHighlight(OneHighlight.newBuilder().setText("found").setIsHit(false).build())
+                .build();
+        assertEquals(expected, suggestLookupHighLight);
+
+        assertEquals(10, results.get(1).getWeight());
+        assertEquals("foobaz", results.get(1).getPayload());
+        suggestLookupHighLight = results.get(1).getSuggestLookupHighlight();
+        expected = SuggestLookupHighlight.newBuilder()
+                .addOneHighlight(OneHighlight.newBuilder().setText("lo").setIsHit(true).build())
+                .addOneHighlight(OneHighlight.newBuilder().setText("ve").setIsHit(false).build())
+                .addOneHighlight(OneHighlight.newBuilder().setText(" ").setIsHit(false).build())
+                .addOneHighlight(OneHighlight.newBuilder().setText("lo").setIsHit(true).build())
+                .addOneHighlight(OneHighlight.newBuilder().setText("st").setIsHit(false).build())
+                .build();
+        assertEquals(expected, suggestLookupHighLight);
+    }
+
+    @Test
+    public void testAnalyzingSuggest() throws Exception {
+        GrpcServer.TestServer testAddDocs = new GrpcServer.TestServer(grpcServer, true, Mode.STANDALONE);
+        Writer fstream = new OutputStreamWriter(new FileOutputStream(tempFile.toFile()), "UTF-8");
+        BufferedWriter out = new BufferedWriter(fstream);
+        out.write("5\u001flucene\u001ffoobar\n");
+        out.write("10\u001flucifer\u001ffoobar\n");
+        out.write("15\u001flove\u001ffoobar\n");
+        out.write("5\u001ftheories take time\u001ffoobar\n");
+        out.write("5\u001fthe time is now\u001ffoobar\n");
+        out.close();
+        BuildSuggestResponse response = sendBuildSuggest("suggest", false, false, Suggester.ANALYZING);
+        assertEquals(5, response.getCount());
+
+        SuggestLookupRequest.Builder suggestLookupBuilder = SuggestLookupRequest.newBuilder();
+        suggestLookupBuilder.setText("l");
+        suggestLookupBuilder.setSuggestName("suggest");
+        suggestLookupBuilder.setIndexName("test_index");
+        SuggestLookupResponse suggestResponse = grpcServer.getBlockingStub().suggestLookup(suggestLookupBuilder.build());
+        List<OneSuggestLookupResponse> results = suggestResponse.getResultsList();
+
+        assertEquals(3, results.size());
+
+        assertEquals("love", results.get(0).getKey());
+        assertEquals(15, results.get(0).getWeight());
+        assertEquals("foobar", results.get(0).getPayload());
+
+        assertEquals("lucifer", results.get(1).getKey());
+        assertEquals(10, results.get(1).getWeight());
+        assertEquals("foobar", results.get(1).getPayload());
+
+        assertEquals("lucene", results.get(2).getKey());
+        assertEquals(5, results.get(2).getWeight());
+        assertEquals("foobar", results.get(2).getPayload());
+
+        suggestLookupBuilder = SuggestLookupRequest.newBuilder();
+        suggestLookupBuilder.setText("the");
+        suggestLookupBuilder.setSuggestName("suggest");
+        suggestLookupBuilder.setIndexName("test_index");
+        suggestResponse = grpcServer.getBlockingStub().suggestLookup(suggestLookupBuilder.build());
+        results = suggestResponse.getResultsList();
+
+        assertEquals(2, results.size());
+
+        assertEquals("theories take time", results.get(0).getKey());
+        assertEquals(5, results.get(0).getWeight());
+        assertEquals("foobar", results.get(0).getPayload());
+
+    }
+
+    @Test
+    public void testFuzzySuggest() throws Exception {
+        GrpcServer.TestServer testAddDocs = new GrpcServer.TestServer(grpcServer, true, Mode.STANDALONE);
+        Writer fstream = new OutputStreamWriter(new FileOutputStream(tempFile.toFile()), "UTF-8");
+        BufferedWriter out = new BufferedWriter(fstream);
+        out.write("15\u001flove lost\u001ffoobar\n");
+        out.close();
+
+        BuildSuggestResponse result = sendBuildSuggest("suggest3", false, false, Suggester.FUZZY);
+        assertEquals(1, result.getCount());
+
+        // 1 transposition and this is prefix of "love":
+        SuggestLookupRequest.Builder suggestLookupBuilder = SuggestLookupRequest.newBuilder();
+        suggestLookupBuilder.setText("lvo");
+        suggestLookupBuilder.setSuggestName("suggest3");
+        suggestLookupBuilder.setIndexName("test_index");
+        SuggestLookupResponse suggestResponse = grpcServer.getBlockingStub().suggestLookup(suggestLookupBuilder.build());
+        List<OneSuggestLookupResponse> results = suggestResponse.getResultsList();
+
+        assertEquals(15, results.get(0).getWeight());
+        assertEquals("love lost", results.get(0).getKey());
         assertEquals("foobar", results.get(0).getPayload());
     }
 
+    /**
+     * Build a suggest, pulling suggestions/weights/payloads from stored fields.
+     */
+    @Test
+    public void testFromStoredFields() throws Exception {
+        GrpcServer.TestServer testAddDocs = new GrpcServer.TestServer(grpcServer, false, Mode.STANDALONE);
+        new GrpcServer.IndexAndRoleManager(grpcServer).createStartIndexAndRegisterFields(Mode.STANDALONE, 0, false, "registerFieldsSuggest.json");
+        AddDocumentResponse addDocumentResponse = testAddDocs.addDocuments("addSuggestDocs.csv");
+        BuildSuggestRequest.Builder buildSuggestRequestBuilder = BuildSuggestRequest.newBuilder();
+        buildSuggestRequestBuilder.setSuggestName("suggest");
+        buildSuggestRequestBuilder.setIndexName("test_index");
+        buildSuggestRequestBuilder.setAnalyzingSuggester(AnalyzingSuggester.newBuilder().setAnalyzer("default").build());
+        buildSuggestRequestBuilder.setNonLocalSource(SuggestNonLocalSource.newBuilder()
+                .setIndexGen(Long.valueOf(addDocumentResponse.getGenId()))
+                .setSuggestField("text")
+                .setWeightField("weight")
+                .setPayloadField("payload")
+                .build());
+        BuildSuggestResponse response = grpcServer.getBlockingStub().buildSuggest(buildSuggestRequestBuilder.build());
+        // nocommit count isn't returned for stored fields source:
+        assertEquals(2, response.getCount());
+        SuggestLookupRequest.Builder suggestLookupBuilder = SuggestLookupRequest.newBuilder();
+        suggestLookupBuilder.setText("the");
+        suggestLookupBuilder.setSuggestName("suggest");
+        suggestLookupBuilder.setIndexName("test_index");
+        SuggestLookupResponse suggestResponse = grpcServer.getBlockingStub().suggestLookup(suggestLookupBuilder.build());
+        List<OneSuggestLookupResponse> results = suggestResponse.getResultsList();
+
+        assertEquals(2, results.get(0).getWeight());
+        assertEquals("the dog barks", results.get(0).getKey());
+        assertEquals("payload2", results.get(0).getPayload());
+        assertEquals(1, results.get(1).getWeight());
+        assertEquals("the cat meows", results.get(1).getKey());
+        assertEquals("payload1", results.get(1).getPayload());
+    }
+
+    /**
+     * Build a suggest, pulling suggestions/payloads from
+     * stored fields, and weight from an expression
+     */
+    @Test
+    public void testFromStoredFieldsWithWeightExpression() throws Exception {
+        GrpcServer.TestServer testAddDocs = new GrpcServer.TestServer(grpcServer, false, Mode.STANDALONE);
+        new GrpcServer.IndexAndRoleManager(grpcServer).createStartIndexAndRegisterFields(Mode.STANDALONE, 0, false, "registerFieldsSuggestExpr.json");
+        AddDocumentResponse addDocumentResponse = testAddDocs.addDocuments("addSuggestDocsExpr.csv");
+        BuildSuggestRequest.Builder buildSuggestRequestBuilder = BuildSuggestRequest.newBuilder();
+        buildSuggestRequestBuilder.setSuggestName("suggest");
+        buildSuggestRequestBuilder.setIndexName("test_index");
+        buildSuggestRequestBuilder.setAnalyzingSuggester(AnalyzingSuggester.newBuilder().setAnalyzer("default").build());
+        buildSuggestRequestBuilder.setNonLocalSource(SuggestNonLocalSource.newBuilder()
+                .setIndexGen(Long.valueOf(addDocumentResponse.getGenId()))
+                .setSuggestField("text")
+                .setWeightExpression("-negWeight")
+                .setPayloadField("payload")
+                .build());
+        BuildSuggestResponse response = grpcServer.getBlockingStub().buildSuggest(buildSuggestRequestBuilder.build());
+        assertEquals(2, response.getCount());
+
+        // nocommit count isn't returned for stored fields source:
+        SuggestLookupRequest.Builder suggestLookupBuilder = SuggestLookupRequest.newBuilder();
+        suggestLookupBuilder.setText("the");
+        suggestLookupBuilder.setSuggestName("suggest");
+        suggestLookupBuilder.setIndexName("test_index");
+        SuggestLookupResponse suggestResponse = grpcServer.getBlockingStub().suggestLookup(suggestLookupBuilder.build());
+        List<OneSuggestLookupResponse> results = suggestResponse.getResultsList();
+
+        assertEquals(2, results.get(0).getWeight());
+        assertEquals("the dog barks", results.get(0).getKey());
+        assertEquals("payload2", results.get(0).getPayload());
+        assertEquals(1, results.get(1).getWeight());
+        assertEquals("the cat meows", results.get(1).getKey());
+        assertEquals("payload1", results.get(1).getPayload());
+
+    }
+
+    @Test
+    public void testInfixSuggesterWithContexts() throws Exception {
+        GrpcServer.TestServer testAddDocs = new GrpcServer.TestServer(grpcServer, true, Mode.STANDALONE);
+
+        Writer fstream = new OutputStreamWriter(new FileOutputStream(tempFile.toFile()), "UTF-8");
+        BufferedWriter out = new BufferedWriter(fstream);
+        out.write("15\u001flove lost\u001ffoobar\u001flucene\n");
+        out.close();
+
+        BuildSuggestResponse response = sendBuildSuggest("suggest", true, false, Suggester.INFIX);
+        assertEquals(1, response.getCount());
+        SuggestLookupRequest.Builder suggestLookupBuilder = SuggestLookupRequest.newBuilder();
+        suggestLookupBuilder.setText("lov");
+        suggestLookupBuilder.setSuggestName("suggest");
+        suggestLookupBuilder.setIndexName("test_index");
+        suggestLookupBuilder.setHighlight(true);
+        suggestLookupBuilder.addContexts("lucene");
+        SuggestLookupResponse suggestResponse = grpcServer.getBlockingStub().suggestLookup(suggestLookupBuilder.build());
+        List<OneSuggestLookupResponse> results = suggestResponse.getResultsList();
+        assertEquals(1, results.size());
+        assertEquals(15, results.get(0).getWeight());
+        assertEquals("foobar", results.get(0).getPayload());
+    }
 }

--- a/src/test/resources/addSuggestDocs.csv
+++ b/src/test/resources/addSuggestDocs.csv
@@ -1,0 +1,3 @@
+text,weight,payload
+the cat meows,1,payload1
+the dog barks,2,payload2

--- a/src/test/resources/addSuggestDocsExpr.csv
+++ b/src/test/resources/addSuggestDocsExpr.csv
@@ -1,0 +1,3 @@
+text,negWeight,payload
+the cat meows,-1,payload1
+the dog barks,-2,payload2

--- a/src/test/resources/registerFieldsSuggest.json
+++ b/src/test/resources/registerFieldsSuggest.json
@@ -1,0 +1,23 @@
+{
+  "indexName": "test_index",
+  "field": [
+    {
+      "name": "text",
+      "type": "TEXT",
+      "store": true,
+      "search": false
+    },
+    {
+      "name": "weight",
+      "type": "FLOAT",
+      "store": true,
+      "search": false
+    },
+    {
+      "name": "payload",
+      "type": "TEXT",
+      "store": true,
+      "search": false
+    }
+  ]
+}

--- a/src/test/resources/registerFieldsSuggestExpr.json
+++ b/src/test/resources/registerFieldsSuggestExpr.json
@@ -1,0 +1,22 @@
+{
+  "indexName": "test_index",
+  "field": [
+    {
+      "name": "text",
+      "type": "TEXT",
+      "store": true,
+      "search": false
+    },
+    {
+      "name": "negWeight",
+      "type": "FLOAT",
+      "sort": true
+    },
+    {
+      "name": "payload",
+      "type": "TEXT",
+      "store": true,
+      "search": false
+    }
+  ]
+}


### PR DESCRIPTION
Added support for Suggestions. Provided two endpoints `BuildSuggestHandler` to build suggesters as per the protoBuf API and an `SuggestLookupHandler` to lookup suggestions, with highlights ability for InfixAnalyzer. Note that this only supports StandardAnalyzer for now