### PR TITLE
add support for createSnapshot release

### DIFF
--- a/src/main/java/org/apache/platypus/server/grpc/LuceneServer.java
+++ b/src/main/java/org/apache/platypus/server/grpc/LuceneServer.java
@@ -662,6 +662,46 @@ public class LuceneServer {
                         .asRuntimeException());
             }
         }
+
+        @Override
+        public void createSnapshot(CreateSnapshotRequest createSnapshotRequest, StreamObserver<CreateSnapshotResponse> responseObserver) {
+            try {
+                IndexState indexState = globalState.getIndex(createSnapshotRequest.getIndexName());
+                CreateSnapshotHandler createSnapshotHandler = new CreateSnapshotHandler();
+                CreateSnapshotResponse reply = createSnapshotHandler.handle(indexState, createSnapshotRequest);
+                logger.info(String.format("CreateSnapshotHandler returned results %s", reply.toString()));
+                responseObserver.onNext(reply);
+                responseObserver.onCompleted();
+            } catch (Exception e) {
+                logger.warn(String.format("error while trying to createSnapshot for index %s", createSnapshotRequest.getIndexName()), e);
+                responseObserver.onError(Status
+                        .UNKNOWN
+                        .withDescription(String.format("error while trying to createSnapshot for index %s", createSnapshotRequest.getIndexName()))
+                        .augmentDescription(e.getMessage())
+                        .asRuntimeException());
+            }
+        }
+
+        @Override
+        public void releaseSnapshot(ReleaseSnapshotRequest releaseSnapshotRequest, StreamObserver<ReleaseSnapshotResponse> responseObserver) {
+            try {
+                IndexState indexState = globalState.getIndex(releaseSnapshotRequest.getIndexName());
+                ReleaseSnapshotHandler releaseSnapshotHandler = new ReleaseSnapshotHandler();
+                ReleaseSnapshotResponse reply = releaseSnapshotHandler.handle(indexState, releaseSnapshotRequest);
+                logger.info(String.format("CreateSnapshotHandler returned results %s", reply.toString()));
+                responseObserver.onNext(reply);
+                responseObserver.onCompleted();
+            } catch (Exception e) {
+                logger.warn(String.format("error while trying to releaseSnapshott for index %s", releaseSnapshotRequest.getIndexName()), e);
+                responseObserver.onError(Status
+                        .UNKNOWN
+                        .withDescription(String.format("error while trying to releaseSnapshott for index %s", releaseSnapshotRequest.getIndexName()))
+                        .augmentDescription(e.getMessage())
+                        .asRuntimeException());
+            }
+
+        }
+
     }
 
     static class ReplicationServerImpl extends ReplicationServerGrpc.ReplicationServerImplBase {

--- a/src/main/java/org/apache/platypus/server/luceneserver/CreateSnapshotHandler.java
+++ b/src/main/java/org/apache/platypus/server/luceneserver/CreateSnapshotHandler.java
@@ -1,0 +1,113 @@
+/*
+ *
+ *  *
+ *  *  Copyright 2019 Yelp Inc.
+ *  *
+ *  *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  *  you may not use this file except in compliance with the License.
+ *  *  You may obtain a copy of the License at
+ *  *       http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *  Unless required by applicable law or agreed to in writing, software
+ *  *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ *  *  either express or implied.
+ *  *  See the License for the specific language governing permissions and
+ *  *  limitations under the License.
+ *  *
+ *  *
+ *
+ *
+ */
+
+package org.apache.platypus.server.luceneserver;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import org.apache.lucene.facet.taxonomy.SearcherTaxonomyManager;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexCommit;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.SegmentInfos;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.platypus.server.grpc.CreateSnapshotRequest;
+import org.apache.platypus.server.grpc.CreateSnapshotResponse;
+
+import java.io.IOException;
+
+public class CreateSnapshotHandler implements Handler<CreateSnapshotRequest, CreateSnapshotResponse> {
+    @Override
+    public CreateSnapshotResponse handle(IndexState indexState, CreateSnapshotRequest createSnapshotRequest) throws HandlerException {
+        try {
+            return createSnapshot(indexState, createSnapshotRequest);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public CreateSnapshotResponse createSnapshot(IndexState indexState, CreateSnapshotRequest createSnapshotRequest) throws IOException {
+        indexState.verifyStarted();
+
+        final ShardState shardState = indexState.getShard(0);
+
+        if (!indexState.hasCommit()) {
+            throw new RuntimeException("this index has no commits; please call commit first");
+        }
+
+        // nocommit not thread safe vs commitHandler?
+        final boolean openSearcher = createSnapshotRequest.getOpenSearcher();
+        IndexCommit c = shardState.snapshots.snapshot();
+        IndexCommit tc = shardState.taxoSnapshots.snapshot();
+        long stateGen = indexState.incRefLastCommitGen();
+
+        JsonObject result = new JsonObject();
+
+        SegmentInfos sis = SegmentInfos.readCommit(shardState.origIndexDir, c.getSegmentsFileName());
+        shardState.snapshotGenToVersion.put(c.getGeneration(), sis.getVersion());
+
+        if (openSearcher) {
+            // nocommit share w/ SearchHandler's method:
+            // TODO: this "reverse-NRT" is silly ... we need a reader
+            // pool somehow:
+            SearcherTaxonomyManager.SearcherAndTaxonomy s2 = shardState.acquire();
+            try {
+                // This returns a new reference to us, which
+                // is decRef'd in the finally clause after
+                // search is done:
+                long t0 = System.nanoTime();
+                IndexReader r = DirectoryReader.openIfChanged((DirectoryReader) s2.searcher.getIndexReader(), c);
+                IndexSearcher s = new IndexSearcher(r);
+                try {
+                    shardState.slm.record(s);
+                } finally {
+                    s.getIndexReader().decRef();
+                }
+                long t1 = System.nanoTime();
+                result.addProperty("newSnapshotSearcherOpenMS", ((t1-t0)/1000000.0));
+            } finally {
+                shardState.release(s2);
+            }
+        }
+
+        // TODO: suggest state?
+        // nocommit must also snapshot snapshots state!?
+        // hard to think about
+
+        fillFiles(result, "index", c);
+        fillFiles(result, "taxonomy", tc);
+        JsonArray arr = new JsonArray();
+        arr.add("state." + stateGen);
+        result.add("state", arr);
+        result.addProperty("id", c.getGeneration() + ":" + tc.getGeneration() + ":" + stateGen);
+        return CreateSnapshotResponse.newBuilder().setResponse(result.toString()).build();
+    }
+
+    static void fillFiles(JsonObject o, String path, IndexCommit commit) throws IOException {
+        JsonArray arr = new JsonArray();
+        for(String sub : commit.getFileNames()) {
+            arr.add(sub);
+        }
+        o.add(path, arr);
+    }
+
+}

--- a/src/main/java/org/apache/platypus/server/luceneserver/GlobalState.java
+++ b/src/main/java/org/apache/platypus/server/luceneserver/GlobalState.java
@@ -111,6 +111,10 @@ public class GlobalState implements Closeable {
         return port;
     }
 
+    public Path getStateDir() {
+        return stateDir;
+    }
+
     //need to call this first time LuceneServer comes up
     private void loadIndexNames() throws IOException {
         long gen = IndexState.getLastGen(stateDir, "indices");

--- a/src/main/java/org/apache/platypus/server/luceneserver/ReleaseSnapshotHandler.java
+++ b/src/main/java/org/apache/platypus/server/luceneserver/ReleaseSnapshotHandler.java
@@ -1,0 +1,51 @@
+/*
+ *
+ *  *
+ *  *  Copyright 2019 Yelp Inc.
+ *  *
+ *  *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  *  you may not use this file except in compliance with the License.
+ *  *  You may obtain a copy of the License at
+ *  *       http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *  Unless required by applicable law or agreed to in writing, software
+ *  *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ *  *  either express or implied.
+ *  *  See the License for the specific language governing permissions and
+ *  *  limitations under the License.
+ *  *
+ *  *
+ *
+ *
+ */
+
+package org.apache.platypus.server.luceneserver;
+
+import org.apache.platypus.server.grpc.ReleaseSnapshotRequest;
+import org.apache.platypus.server.grpc.ReleaseSnapshotResponse;
+
+import java.io.IOException;
+
+public class ReleaseSnapshotHandler implements Handler<ReleaseSnapshotRequest, ReleaseSnapshotResponse> {
+    @Override
+    public ReleaseSnapshotResponse handle(IndexState indexState, ReleaseSnapshotRequest releaseSnapshotRequest) throws HandlerException {
+        final ShardState shardState = indexState.getShard(0);
+        final IndexState.Gens gens = new IndexState.Gens(releaseSnapshotRequest.getId(), "id");
+        // SearcherLifetimeManager pruning thread will drop
+        // the searcher (if it's old enough) next time it
+        // wakes up:
+        try {
+            shardState.snapshots.release(gens.indexGen);
+            shardState.writer.deleteUnusedFiles();
+            shardState.snapshotGenToVersion.remove(gens.indexGen);
+
+            shardState.taxoSnapshots.release(gens.taxoGen);
+            shardState.taxoInternalWriter.deleteUnusedFiles();
+            indexState.decRef(gens.stateGen);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return ReleaseSnapshotResponse.newBuilder().setSuccess(true).build();
+    }
+}

--- a/src/main/proto/luceneserver.proto
+++ b/src/main/proto/luceneserver.proto
@@ -69,6 +69,29 @@ service LuceneServer {
     rpc updateSuggest (BuildSuggestRequest) returns (BuildSuggestResponse) {
     }
 
+    /*
+    Creates a snapshot in the index, which is saved point-in-time view of the last commit
+    in the index such that no files referenced by that snapshot will be deleted by ongoing
+    indexing until the snapshot is released with @releaseSnapshot.  Note that this will
+    reference the last commit, so be sure to call commit first if you have pending changes
+    that you'd like to be included in the snapshot.
+    This can be used for backup purposes, i.e. after creating the snapshot you can copy
+    all referenced files to backup storage, and then release the snapshot once complete.
+    To restore the backup, just copy all the files back and restart the server.
+    It can also be used for transactional purposes, i.e. if you sometimes need to search a
+    specific snapshot instead of the current live index. Creating a snapshot is very fast
+    (does not require any file copying), but over time it will consume extra disk space as
+    old segments are merged in the index.  Be sure to release the snapshot once you're done.
+    Snapshots survive shutdown and restart of the server.  Returns all protected filenames
+    referenced by this snapshot: these files will not change and will not be deleted until
+    the snapshot is released.  This returns the directories and files referenced by the snapshot.
+    */
+    rpc createSnapshot (CreateSnapshotRequest) returns (CreateSnapshotResponse) {
+    }
+
+    /* releases a snapshot previously created with @createSnapshot. */
+    rpc releaseSnapshot (ReleaseSnapshotRequest) returns (ReleaseSnapshotResponse) {
+    }
 }
 
 //The ReplicationServer service definition.
@@ -539,6 +562,39 @@ message FuzzySuggester {
     bool unicodeAware = 12; //True if all edits are measured in unicode characters, not UTF-8 bytes
 }
 
+/*
+Creates a snapshot in the index, which is saved point-in-time view of the last commit in the
+index such that no files referenced by that snapshot will be deleted by ongoing indexing until
+the snapshot is released with @releaseSnapshot.  Note that this will reference the last commit,
+ so be sure to call commit first if you have pending changes that you'd like to be included in
+ the snapshot.<p>This can be used for backup purposes, i.e. after creating the snapshot you can
+ copy all referenced files to backup storage, and then release the snapshot once complete.
+ To restore the backup, just copy all the files back and restart the server.  It can also
+ be used for transactional purposes, i.e. if you sometimes need to search a specific snapshot
+ instead of the current live index.<p>Creating a snapshot is very fast (does not require any
+ file copying), but over time it will consume extra disk space as old segments are merged in
+ the index.  Be sure to release the snapshot once you're done.  Snapshots survive shutdown
+ and restart of the server.  Returns all protected filenames referenced by this snapshot:
+ these files will not change and will not be deleted until the snapshot is released.
+ This returns the directories and files referenced by the snapshot.
+ */
+message CreateSnapshotRequest {
+    string indexName = 1; //name of the index to snapshot;
+    bool openSearcher = 2; //Pass true if you intend to do searches against this snapshot, by passing searcher: {snapshot: X} to @search
+}
+
+message CreateSnapshotResponse {
+    string response = 1; //TODO dont use json string
+}
+
+message ReleaseSnapshotRequest {
+    string indexName = 1; // name of snapshotted index to be released
+    string id = 2; //The id for this snapshot; this must have been previously created via @createSnapshot.
+}
+
+message ReleaseSnapshotResponse {
+    bool success = 1; //true if successful
+}
 
 message AddReplicaRequest {
     int32 magicNumber = 1; //magic number send on all requests since these are meant for internal communication only

--- a/src/test/java/org/apache/platypus/server/grpc/GrpcServer.java
+++ b/src/test/java/org/apache/platypus/server/grpc/GrpcServer.java
@@ -83,10 +83,14 @@ public class GrpcServer {
         if (luceneServer != null && luceneServerManagedChannel != null) {
             luceneServer.shutdown();
             luceneServerManagedChannel.shutdown();
+            luceneServer = null;
+            luceneServerManagedChannel = null;
         }
         if (replicationServer != null && replicationServerManagedChannel != null) {
             replicationServer.shutdown();
             replicationServerManagedChannel.shutdown();
+            replicationServer = null;
+            replicationServerStub = null;
         }
     }
 
@@ -138,8 +142,6 @@ public class GrpcServer {
             stub = null;
             luceneServer = null;
             luceneServerManagedChannel = null;
-
-
         }
 
     }


### PR DESCRIPTION
Creates a snapshot in the index, which is saved point-in-time view of the last commit in the index such that no files referenced by that snapshot will be deleted by ongoing indexing until the snapshot is released with @releaseSnapshot.  Note that this will reference the last commit, so be sure to call commit first if you have pending changes that you'd like to be included in the snapshot. 

This can be used for backup purposes, i.e. after creating the snapshot you can copy all referenced files to backup storage, and then release the snapshot once complete.

To restore the backup, just copy all the files back and restart the server.