### PR TITLE
Added backup endpoint to s3 and restore on startIndex for Primary and Standalone Mode

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ def spatial4jVersion = '0.7'
 def s3mockVersion = '0.2.5'
 def commonsCompressVersion = '1.19'
 def awsJavaSdkVersion = '1.11.695'
+def guicedeeVersion = '1.0.1.7-jre13'
 
 dependencies {
     //grpc deps
@@ -53,6 +54,7 @@ dependencies {
     implementation "org.apache.commons:commons-compress:${commonsCompressVersion}"
     implementation "com.amazonaws:aws-java-sdk-core:${awsJavaSdkVersion}"
     implementation "com.amazonaws:aws-java-sdk-s3:${awsJavaSdkVersion}"
+    implementation "com.guicedee.services:guice:${guicedeeVersion}"
 
     //lucene deps
     implementation "org.apache.lucene:lucene-core:${luceneVersion}"
@@ -152,6 +154,7 @@ task buildDocs() {
     dependsOn 'dockerRun'
     tasks.findByName('dockerRun').mustRunAfter 'pullBuildDocsImage'
 }
+
 
 //Dynamic exclude through property defined in the build.gradle file
 //e.g. to include perfTests: ./gradlew test -PincludePerfTests=true

--- a/src/main/java/org/apache/platypus/LuceneServerModule.java
+++ b/src/main/java/org/apache/platypus/LuceneServerModule.java
@@ -1,0 +1,106 @@
+/*
+ *
+ *  *
+ *  *  Copyright 2019 Yelp Inc.
+ *  *
+ *  *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  *  you may not use this file except in compliance with the License.
+ *  *  You may obtain a copy of the License at
+ *  *       http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *  Unless required by applicable law or agreed to in writing, software
+ *  *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ *  *  either express or implied.
+ *  *  See the License for the specific language governing permissions and
+ *  *  limitations under the License.
+ *  *
+ *  *
+ *
+ *
+ */
+
+package org.apache.platypus;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.AnonymousAWSCredentials;
+import com.amazonaws.auth.profile.ProfileCredentialsProvider;
+import com.amazonaws.auth.profile.ProfilesConfigFile;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.google.inject.AbstractModule;
+import com.google.inject.Inject;
+import com.google.inject.Provides;
+import com.google.inject.Singleton;
+import org.apache.platypus.server.config.LuceneServerConfiguration;
+import org.apache.platypus.server.utils.Archiver;
+import org.apache.platypus.server.utils.ArchiverImpl;
+import org.apache.platypus.server.utils.Tar;
+import org.apache.platypus.server.utils.TarImpl;
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static org.apache.platypus.server.config.LuceneServerConfiguration.DEFAULT_BOTO_CFG_PATH;
+
+public class LuceneServerModule extends AbstractModule {
+
+    private final String[] args;
+
+    public LuceneServerModule(String[] args) {
+        this.args = args;
+    }
+
+    @Override
+    public void configure() {
+        bind(Tar.class).to(TarImpl.class);
+    }
+
+    @Inject
+    @Singleton
+    @Provides
+    protected AmazonS3 providesAmazonS3(LuceneServerConfiguration luceneServerConfiguration) {
+        if (luceneServerConfiguration.getBotoCfgPath().equals(DEFAULT_BOTO_CFG_PATH.toString())) {
+            return AmazonS3ClientBuilder.standard()
+                    .withCredentials(new AWSStaticCredentialsProvider(new AnonymousAWSCredentials()))
+                    .withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration("dummyService", "dummyRegion"))
+                    .build();
+        } else {
+            Path botoCfgPath = Paths.get(luceneServerConfiguration.getBotoCfgPath());
+            final ProfilesConfigFile profilesConfigFile = new ProfilesConfigFile(botoCfgPath.toFile());
+            final AWSCredentialsProvider awsCredentialsProvider = new ProfileCredentialsProvider(profilesConfigFile, "default");
+            return AmazonS3ClientBuilder.standard()
+                    .withCredentials(awsCredentialsProvider).build();
+        }
+    }
+
+    @Inject
+    @Singleton
+    @Provides
+    protected Archiver providesArchiver(LuceneServerConfiguration luceneServerConfiguration, AmazonS3 amazonS3) {
+        Path archiveDir = Paths.get(luceneServerConfiguration.getArchiveDirectory());
+        return new ArchiverImpl(amazonS3, luceneServerConfiguration.getBucketName(), archiveDir, new TarImpl());
+    }
+
+    @Inject
+    @Singleton
+    @Provides
+    protected LuceneServerConfiguration providesLuceneServerConfiguration() throws FileNotFoundException {
+        LuceneServerConfiguration luceneServerConfiguration;
+        if (args.length == 0) {
+            Path filePath = Paths.get("src", "main", "resources", "lucene_server_default_configuration.yaml");
+            luceneServerConfiguration = new Yaml().load(new FileInputStream(filePath.toFile()));
+            luceneServerConfiguration.setStateDir(LuceneServerConfiguration.DEFAULT_USER_STATE_DIR.toString());
+        } else {
+            luceneServerConfiguration = new Yaml().load(new FileInputStream(args[0]));
+        }
+        return luceneServerConfiguration;
+    }
+
+}
+

--- a/src/main/java/org/apache/platypus/server/config/LuceneServerConfiguration.java
+++ b/src/main/java/org/apache/platypus/server/config/LuceneServerConfiguration.java
@@ -19,17 +19,44 @@
 
 package org.apache.platypus.server.config;
 
+import com.google.inject.Inject;
+
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
 public class LuceneServerConfiguration {
     public final static Path DEFAULT_USER_STATE_DIR = Paths.get(System.getProperty("user.home"), "lucene", "server");
+    public final static Path DEFAULT_ARCHIVER_DIR = Paths.get(DEFAULT_USER_STATE_DIR.toString(), "archiver");
+    public final static Path DEFAULT_BOTO_CFG_PATH = Paths.get(DEFAULT_USER_STATE_DIR.toString(), "boto.cfg");
+    private static final String DEFAULT_BUCKET_NAME = "DEFAULT_ARCHIVE_BUCKET";
 
     private int port;
     private int replicationPort;
     private String nodeName;
     private String stateDir;
     private String hostName;
+    private String archiveDirectory = DEFAULT_ARCHIVER_DIR.toString();
+    private String botoCfgPath = DEFAULT_BOTO_CFG_PATH.toString();
+    private String bucketName = DEFAULT_BUCKET_NAME;
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("LuceneServerConfiguration{");
+        sb.append("port=").append(port);
+        sb.append(", replicationPort=").append(replicationPort);
+        sb.append(", nodeName='").append(nodeName).append('\'');
+        sb.append(", stateDir='").append(stateDir).append('\'');
+        sb.append(", hostName='").append(hostName).append('\'');
+        sb.append(", archiveDirectory='").append(archiveDirectory).append('\'');
+        sb.append(", botoCfgPath='").append(botoCfgPath).append('\'');
+        sb.append(", bucketName='").append(bucketName).append('\'');
+        sb.append('}');
+        return sb.toString();
+    }
+
+    @Inject
+    public LuceneServerConfiguration() {
+    }
 
     public int getPort() {
         return port;
@@ -71,17 +98,31 @@ public class LuceneServerConfiguration {
         this.hostName = hostName;
     }
 
-    @Override
-    public String toString() {
-        final StringBuilder sb = new StringBuilder("LuceneServerConfiguration{");
-        sb.append("port=").append(port);
-        sb.append(", replicationPort=").append(replicationPort);
-        sb.append(", nodeName='").append(nodeName).append('\'');
-        sb.append(", stateDir=").append(stateDir);
-        sb.append(", hostName='").append(hostName).append('\'');
-        sb.append('}');
-        return sb.toString();
+
+    public String getBotoCfgPath() {
+        return botoCfgPath;
     }
+
+    public void setBotoCfgPath(String botoCfgPath) {
+        this.botoCfgPath = botoCfgPath;
+    }
+
+    public String getBucketName() {
+        return bucketName;
+    }
+
+    public void setBucketName(String bucketName) {
+        this.bucketName = bucketName;
+    }
+
+    public String getArchiveDirectory() {
+        return archiveDirectory;
+    }
+
+    public void setArchiveDirectory(String archiveDirectory) {
+        this.archiveDirectory = archiveDirectory;
+    }
+
 
     public static class Builder {
         private String hostName;
@@ -89,6 +130,9 @@ public class LuceneServerConfiguration {
         private int port;
         private String nodeName;
         private Path stateDir;
+        private String archiveDirectory;
+        private String botoCfgPath;
+        private String bucketName;
 
         public Builder() {
             //set default values
@@ -97,6 +141,9 @@ public class LuceneServerConfiguration {
             this.stateDir = DEFAULT_USER_STATE_DIR;
             this.port = 50051;
             this.replicationPort = 50052;
+            this.archiveDirectory = DEFAULT_ARCHIVER_DIR.toString();
+            this.botoCfgPath = DEFAULT_BOTO_CFG_PATH.toString();
+            this.bucketName = DEFAULT_BUCKET_NAME;
         }
 
         public Builder withStateDir(String tempStateDir) {
@@ -125,6 +172,21 @@ public class LuceneServerConfiguration {
             return this;
         }
 
+        public Builder withArchiveDirectory(String archiveDirectory) {
+            this.archiveDirectory = archiveDirectory;
+            return this;
+        }
+
+        public Builder withBotoCfgPath(String botoCfgPath) {
+            this.botoCfgPath = botoCfgPath;
+            return this;
+        }
+
+        public Builder withBucketName(String bucketName) {
+            this.bucketName = bucketName;
+            return this;
+        }
+
         public LuceneServerConfiguration build() {
             LuceneServerConfiguration luceneServerConfiguration = new LuceneServerConfiguration();
             luceneServerConfiguration.nodeName = this.nodeName;
@@ -132,6 +194,9 @@ public class LuceneServerConfiguration {
             luceneServerConfiguration.port = this.port;
             luceneServerConfiguration.hostName = this.hostName;
             luceneServerConfiguration.replicationPort = this.replicationPort;
+            luceneServerConfiguration.archiveDirectory = this.archiveDirectory;
+            luceneServerConfiguration.botoCfgPath = this.botoCfgPath;
+            luceneServerConfiguration.bucketName = this.bucketName;
             return luceneServerConfiguration;
         }
 

--- a/src/main/java/org/apache/platypus/server/luceneserver/BackupIndexRequestHandler.java
+++ b/src/main/java/org/apache/platypus/server/luceneserver/BackupIndexRequestHandler.java
@@ -1,0 +1,85 @@
+/*
+ *
+ *  *
+ *  *  Copyright 2019 Yelp Inc.
+ *  *
+ *  *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  *  you may not use this file except in compliance with the License.
+ *  *  You may obtain a copy of the License at
+ *  *       http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *  Unless required by applicable law or agreed to in writing, software
+ *  *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ *  *  either express or implied.
+ *  *  See the License for the specific language governing permissions and
+ *  *  limitations under the License.
+ *  *
+ *  *
+ *
+ *
+ */
+
+package org.apache.platypus.server.luceneserver;
+
+import org.apache.platypus.server.grpc.BackupIndexRequest;
+import org.apache.platypus.server.grpc.BackupIndexResponse;
+import org.apache.platypus.server.grpc.CreateSnapshotRequest;
+import org.apache.platypus.server.grpc.CreateSnapshotResponse;
+import org.apache.platypus.server.grpc.ReleaseSnapshotRequest;
+import org.apache.platypus.server.grpc.ReleaseSnapshotResponse;
+import org.apache.platypus.server.utils.Archiver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+
+public class BackupIndexRequestHandler implements Handler<BackupIndexRequest, BackupIndexResponse> {
+    Logger logger = LoggerFactory.getLogger(BackupIndexRequestHandler.class);
+    private final Archiver archiver;
+
+    public BackupIndexRequestHandler(Archiver archiver) {
+        this.archiver = archiver;
+    }
+
+    @Override
+    public BackupIndexResponse handle(IndexState indexState, BackupIndexRequest backupIndexRequest) throws HandlerException {
+        BackupIndexResponse.Builder backupIndexResponseBuilder = BackupIndexResponse.newBuilder();
+        String indexName = backupIndexRequest.getIndexName();
+        CreateSnapshotRequest createSnapshotRequest = CreateSnapshotRequest.newBuilder()
+                .setIndexName(indexName)
+                .build();
+        ReleaseSnapshotResponse releaseSnapshotResponse;
+        try {
+            indexState.commit();
+            CreateSnapshotResponse createSnapshotResponse = new CreateSnapshotHandler().createSnapshot(indexState, createSnapshotRequest);
+            uploadArtifacts(backupIndexRequest.getServiceName(),
+                    backupIndexRequest.getResourceName(), indexState, backupIndexResponseBuilder);
+            ReleaseSnapshotRequest releaseSnapshotRequest = ReleaseSnapshotRequest.newBuilder()
+                    .setIndexName(indexName)
+                    .setSnapshotId(createSnapshotResponse.getSnapshotId()).build();
+            releaseSnapshotResponse = new ReleaseSnapshotHandler().handle(indexState, releaseSnapshotRequest);
+        } catch (IOException e) {
+            logger.error(String.format("Error while trying to backup index %s with serviceName %s, resourceName %s",
+                    indexName, backupIndexRequest.getServiceName(), backupIndexRequest.getResourceName()), e);
+            return backupIndexResponseBuilder.build();
+        }
+
+        return backupIndexResponseBuilder
+                .build();
+    }
+
+    public void uploadArtifacts(String serviceName, String resourceName, IndexState indexState, BackupIndexResponse.Builder backupIndexResponseBuilder) throws IOException {
+        String resourceData = String.format("%s_data", resourceName);
+        String resourceMetadata = String.format("%s_metadata", resourceName);
+        String versionHash = archiver.upload(serviceName, resourceData, indexState.rootDir);
+        archiver.blessVersion(serviceName, resourceData, versionHash);
+        backupIndexResponseBuilder.setDataVersionHash(versionHash);
+
+        versionHash = archiver.upload(serviceName, resourceMetadata, indexState.globalState.stateDir);
+        archiver.blessVersion(serviceName, resourceMetadata, versionHash);
+        backupIndexResponseBuilder.setMetadataVersionHash(versionHash);
+
+    }
+}

--- a/src/main/java/org/apache/platypus/server/luceneserver/Restorable.java
+++ b/src/main/java/org/apache/platypus/server/luceneserver/Restorable.java
@@ -1,0 +1,51 @@
+/*
+ *
+ *  *
+ *  *  Copyright 2019 Yelp Inc.
+ *  *
+ *  *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  *  you may not use this file except in compliance with the License.
+ *  *  You may obtain a copy of the License at
+ *  *       http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *  Unless required by applicable law or agreed to in writing, software
+ *  *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ *  *  either express or implied.
+ *  *  See the License for the specific language governing permissions and
+ *  *  limitations under the License.
+ *  *
+ *  *
+ *
+ *
+ */
+
+package org.apache.platypus.server.luceneserver;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.UUID;
+
+public interface Restorable {
+    String TMP_SUFFIX = ".tmp";
+    Logger logger = LoggerFactory.getLogger(Restorable.class);
+
+    default void restoreDir(Path source, Path target) throws IOException {
+        Path baseSource = source.getParent();
+        Path tempCurrentLink = baseSource.resolve(getTmpName());
+        Path downloadedData = source.resolve(target.getFileName());
+        logger.info("Point new symlink %s to new data %s".format(target.toString(), downloadedData.toString()));
+        Files.createSymbolicLink(tempCurrentLink, downloadedData);
+        Files.move(tempCurrentLink, target, StandardCopyOption.REPLACE_EXISTING);
+    }
+
+    default String getTmpName() {
+        return UUID.randomUUID().toString() + TMP_SUFFIX;
+    }
+
+}

--- a/src/main/java/org/apache/platypus/server/utils/Archiver.java
+++ b/src/main/java/org/apache/platypus/server/utils/Archiver.java
@@ -24,12 +24,11 @@ package org.apache.platypus.server.utils;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.security.MessageDigest;
 
 public interface Archiver {
     Path download(final String serviceName, final String resource) throws IOException;
 
     String upload(final String serviceName, final String resource, Path path) throws IOException;
 
-    void blessVersion(final String serviceName, final String resource, String versionHash) throws IOException;
+    boolean blessVersion(final String serviceName, final String resource, String versionHash) throws IOException;
 }

--- a/src/main/java/org/apache/platypus/server/utils/TarImpl.java
+++ b/src/main/java/org/apache/platypus/server/utils/TarImpl.java
@@ -22,6 +22,7 @@
 
 package org.apache.platypus.server.utils;
 
+import com.google.inject.Inject;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
@@ -40,6 +41,11 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 public class TarImpl implements Tar {
+    @Inject
+    public TarImpl() {
+
+    }
+
     @Override
     public void extractTar(Path sourceFile, Path destDir) throws IOException {
         try (

--- a/src/main/proto/luceneserver.proto
+++ b/src/main/proto/luceneserver.proto
@@ -94,6 +94,10 @@ service LuceneServer {
     /* releases a snapshot previously created with @createSnapshot. */
     rpc releaseSnapshot (ReleaseSnapshotRequest) returns (ReleaseSnapshotResponse) {
     }
+    /* backs up a resource (index) and it associated metadata e.g. settings, schema to s3 */
+    rpc backupIndex (BackupIndexRequest) returns (BackupIndexResponse) {
+    }
+
 }
 
 //The ReplicationServer service definition.
@@ -270,7 +274,7 @@ message StartIndexRequest {
     int64 primaryGen = 3; //primary, the generation of this primary (should increment each time a new primary starts for this index)
     string primaryAddress = 4; //replica, the IP address or host name of the remote primary
     int32 port = 5; //replica, the TCP port of the remote primary
-    bool restore = 6; //primary, restore index from backup
+    RestoreIndex restore = 6; // restore index from backup
 }
 
 enum Mode {
@@ -517,16 +521,41 @@ message CreateSnapshotRequest {
 }
 
 message CreateSnapshotResponse {
-    string response = 1; //TODO dont use json string
+    repeated string indexFiles = 1;
+    repeated string taxonomyFiles = 2;
+    repeated string stateFiles = 3;
+    SnapshotId snapshotId = 4;
+}
+
+message SnapshotId {
+    int64 indexGen = 1;
+    int64 taxonomyGen = 2;
+    int64 stateGen = 3;
 }
 
 message ReleaseSnapshotRequest {
     string indexName = 1; // name of snapshotted index to be released
-    string id = 2; //The id for this snapshot; this must have been previously created via @createSnapshot.
+    SnapshotId snapshotId = 2; //The id for this snapshot; this must have been previously created via @createSnapshot.
 }
 
 message ReleaseSnapshotResponse {
     bool success = 1; //true if successful
+}
+
+message BackupIndexRequest {
+    string indexName = 1; //name of the index to backup
+    string serviceName = 2; // remote storage namespace qualifier for service
+    string resourceName = 3; //remote storage namespace qualifier for resource e.g. indexName
+}
+
+message BackupIndexResponse {
+    string dataVersionHash = 1; //version identifier for data on s3
+    string metadataVersionHash = 2; //version identifier for metadata on s3
+}
+
+message RestoreIndex {
+    string serviceName = 1; // remote storage namespace qualifier for service
+    string resourceName = 2; //remote storage namespace qualifier for resource e.g. indexName
 }
 
 message AddReplicaRequest {

--- a/src/test/java/org/apache/platypus/server/TestIndexManager.java
+++ b/src/test/java/org/apache/platypus/server/TestIndexManager.java
@@ -54,7 +54,6 @@ public class TestIndexManager {
                 .setIndexName(indexName)
                 .setMode(Mode.STANDALONE)
                 .setPrimaryGen(0)
-                .setRestore(false)
                 .build();
         startIndex(standaloneServerClient, startIndexRequest);
         // index docs

--- a/src/test/java/org/apache/platypus/server/YelpReviewsTest.java
+++ b/src/test/java/org/apache/platypus/server/YelpReviewsTest.java
@@ -237,7 +237,6 @@ public class YelpReviewsTest {
                     .setIndexName(INDEX_NAME)
                     .setMode(Mode.PRIMARY)
                     .setPrimaryGen(0)
-                    .setRestore(false)
                     .build();
             startIndex(primaryServerClient, startIndexRequest);
             //start replica index
@@ -246,7 +245,6 @@ public class YelpReviewsTest {
                     .setMode(Mode.REPLICA)
                     .setPrimaryAddress(primaryHostPort.hostName)
                     .setPort(primaryHostPort.replicationPort)
-                    .setRestore(false)
                     .build();
             startIndex(secondaryServerClient, startIndexRequest);
 

--- a/src/test/java/org/apache/platypus/server/grpc/BackupRestoreIndexRequestHandlerTest.java
+++ b/src/test/java/org/apache/platypus/server/grpc/BackupRestoreIndexRequestHandlerTest.java
@@ -1,0 +1,200 @@
+/*
+ *
+ *  *
+ *  *  Copyright 2019 Yelp Inc.
+ *  *
+ *  *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  *  you may not use this file except in compliance with the License.
+ *  *  You may obtain a copy of the License at
+ *  *       http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *  Unless required by applicable law or agreed to in writing, software
+ *  *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ *  *  either express or implied.
+ *  *  See the License for the specific language governing permissions and
+ *  *  limitations under the License.
+ *  *
+ *  *
+ *
+ *
+ */
+
+package org.apache.platypus.server.grpc;
+
+import com.amazonaws.auth.AnonymousAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.google.common.collect.ImmutableList;
+import com.google.gson.Gson;
+import io.findify.s3mock.S3Mock;
+import io.grpc.testing.GrpcCleanupRule;
+import org.apache.platypus.server.luceneserver.GlobalState;
+import org.apache.platypus.server.utils.Archiver;
+import org.apache.platypus.server.utils.ArchiverImpl;
+import org.apache.platypus.server.utils.TarImpl;
+import org.iq80.leveldb.util.FileUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.apache.platypus.server.grpc.GrpcServer.rmDir;
+import static org.apache.platypus.server.grpc.LuceneServerTest.RETRIEVED_VALUES;
+import static org.apache.platypus.server.grpc.LuceneServerTest.checkHits;
+import static org.junit.Assert.assertEquals;
+
+public class BackupRestoreIndexRequestHandlerTest {
+    private final String BUCKET_NAME = "archiver-unittest";
+    private Archiver archiver;
+    private S3Mock api;
+    private AmazonS3 s3;
+    private Path s3Directory;
+    private Path archiverDirectory;
+    private Path stateDir;
+
+    @Rule
+    public final TemporaryFolder folder = new TemporaryFolder();
+
+    /**
+     * This rule manages automatic graceful shutdown for the registered servers and channels at the
+     * end of test.
+     */
+    @Rule
+    public final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
+
+    private GrpcServer grpcServer;
+
+    @Before
+    public void setup() throws IOException {
+        s3Directory = folder.newFolder("s3").toPath();
+        archiverDirectory = folder.newFolder("archiver").toPath();
+        api = S3Mock.create(8011, s3Directory.toAbsolutePath().toString());
+        api.start();
+        s3 = new AmazonS3Client(new AnonymousAWSCredentials());
+        s3.setEndpoint("http://127.0.0.1:8011");
+        s3.createBucket(BUCKET_NAME);
+        archiver = new ArchiverImpl(s3, BUCKET_NAME, archiverDirectory, new TarImpl());
+        stateDir = folder.newFolder("stateDir").toPath();
+        grpcServer = setUpGrpcServer();
+    }
+
+    private GrpcServer setUpGrpcServer() throws IOException {
+        GlobalState globalState = new GlobalState("server", stateDir, null, 9000, 9000);
+        return new GrpcServer(grpcCleanup, folder, false, globalState,
+                "serverRootDir", "test_index", globalState.getPort(), archiver);
+    }
+
+    @After
+    public void teardown() throws IOException {
+        api.shutdown();
+        tearDownGrpcServer();
+    }
+
+    private void tearDownGrpcServer() throws IOException {
+        grpcServer.getGlobalState().close();
+        grpcServer.shutdown();
+        rmDir(Paths.get(grpcServer.getRootDirName()));
+        rmDir(stateDir); //stateDir (mapping of index_name: path index dir on disk)
+    }
+
+    @Test
+    public void testBackupRequestHandlerUpload() throws IOException, InterruptedException {
+        GrpcServer.TestServer testAddDocs = new GrpcServer.TestServer(grpcServer, true, Mode.STANDALONE);
+        testAddDocs.addDocuments();
+
+        backupIndex();
+        Path downloadPath = archiver.download("testservice", "testresource_data");
+        List<String> actual = getFiles(downloadPath);
+        List<String> expected = getFiles(Paths.get("serverRootDir"));
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testRestoreHandler() throws IOException, InterruptedException {
+        GrpcServer.TestServer testAddDocs = new GrpcServer.TestServer(grpcServer, true, Mode.STANDALONE);
+        testAddDocs.addDocuments();
+
+        backupIndex();
+        testAddDocs.addDocuments();
+
+        grpcServer.getBlockingStub().stopIndex(StopIndexRequest.newBuilder().setIndexName("test_index").build());
+
+        deleteIndexAndMetadata();
+
+        grpcServer.getBlockingStub().startIndex(StartIndexRequest.newBuilder()
+                .setIndexName("test_index")
+                .setMode(Mode.STANDALONE)
+                .setRestore(RestoreIndex.newBuilder()
+                        .setServiceName("testservice")
+                        .setResourceName("testresource")
+                        .build())
+                .build());
+
+        grpcServer.getBlockingStub().refresh(RefreshRequest.newBuilder().setIndexName(grpcServer.getTestIndex()).build());
+
+        SearchResponse searchResponse = grpcServer.getBlockingStub().search(SearchRequest.newBuilder()
+                .setIndexName(grpcServer.getTestIndex())
+                .setStartHit(0)
+                .setTopHits(10)
+                .addAllRetrieveFields(RETRIEVED_VALUES)
+                .build());
+
+        String response = searchResponse.getResponse();
+        assertEquals(2, searchResponse.getTotalHits());
+        assertEquals(2, searchResponse.getHitsList().size());
+        SearchResponse.Hit firstHit = searchResponse.getHits(0);
+        checkHits(firstHit);
+        SearchResponse.Hit secondHit = searchResponse.getHits(1);
+        checkHits(secondHit);
+
+    }
+
+    private void deleteIndexAndMetadata() throws IOException {
+        for (Path path : Arrays.asList(stateDir, Paths.get("serverRootDir"))) {
+            rmDir(path);
+        }
+    }
+
+
+    public List<String> getFiles(Path basePath) {
+        List<String> result = new ArrayList<>();
+        ImmutableList<File> childFiles = FileUtils.listFiles(basePath.toFile());
+        for (File childFile : childFiles) {
+            if (Files.isDirectory(childFile.toPath())) {
+                result.addAll(getFiles(childFile.toPath()));
+            } else if (Files.isRegularFile(childFile.toPath())) {
+                result.add(childFile.getName());
+            }
+        }
+        return result.stream()
+                //the versions are bumped post a ReleaseSnapshot hence wont be same as snapshotted backed up version
+                //which will be on version less
+                .filter(x -> !x.startsWith("snapshots") && !x.startsWith("stateRefCounts"))
+                .collect(Collectors.toList());
+    }
+
+
+    private void backupIndex() {
+        grpcServer.getBlockingStub()
+                .backupIndex(BackupIndexRequest.newBuilder()
+                        .setIndexName("test_index")
+                        .setServiceName("testservice")
+                        .setResourceName("testresource")
+                        .build()
+                );
+    }
+
+}

--- a/src/test/java/org/apache/platypus/server/grpc/LuceneServerTest.java
+++ b/src/test/java/org/apache/platypus/server/grpc/LuceneServerTest.java
@@ -477,14 +477,16 @@ public class LuceneServerTest {
         //1. commit
         grpcServer.getBlockingStub().commit(CommitRequest.newBuilder().setIndexName("test_index").build());
         //2. createSnapshot
-        grpcServer.getBlockingStub().createSnapshot(CreateSnapshotRequest.newBuilder().setIndexName("test_index").build());
+        CreateSnapshotResponse createSnapshotResponse = grpcServer.getBlockingStub().createSnapshot(CreateSnapshotRequest.newBuilder().setIndexName("test_index").build());
         //3. copy file over to remote storage
         Path backUpDir = folder.newFolder("backup_data").toPath();
         Path backUpStateDir = folder.newFolder("backup_state").toPath();
         FileUtils.copyDirectory(Paths.get(grpcServer.getRootDirName()).toFile(), backUpDir.toFile());
         FileUtils.copyDirectory(grpcServer.getGlobalState().getStateDir().toFile(), backUpStateDir.toFile());
         //4. releaseSnapshot
-        grpcServer.getBlockingStub().releaseSnapshot(ReleaseSnapshotRequest.newBuilder().setIndexName("test_index").setId("1:1:0").build());
+        grpcServer.getBlockingStub().releaseSnapshot(ReleaseSnapshotRequest.newBuilder()
+                .setIndexName("test_index")
+                .setSnapshotId(createSnapshotResponse.getSnapshotId()).build());
         //5. stop server and remove data and state files.
         tearDownGrpcServer(grpcServer.getGlobalState().getStateDir());
         //Steps to restore an index

--- a/src/test/java/org/apache/platypus/server/grpc/ReplicationTestFailureScenarios.java
+++ b/src/test/java/org/apache/platypus/server/grpc/ReplicationTestFailureScenarios.java
@@ -1,7 +1,15 @@
 package org.apache.platypus.server.grpc;
 
+import com.amazonaws.auth.AnonymousAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.google.gson.Gson;
+import io.findify.s3mock.S3Mock;
 import io.grpc.testing.GrpcCleanupRule;
 import org.apache.platypus.server.luceneserver.GlobalState;
+import org.apache.platypus.server.utils.Archiver;
+import org.apache.platypus.server.utils.ArchiverImpl;
+import org.apache.platypus.server.utils.TarImpl;
 import org.apache.platypus.server.luceneserver.ShardState;
 import org.junit.After;
 import org.junit.Before;
@@ -19,10 +27,7 @@ import java.nio.file.Paths;
 import static org.apache.platypus.server.grpc.GrpcServer.rmDir;
 import static org.apache.platypus.server.grpc.LuceneServerTest.RETRIEVED_VALUES;
 import static org.apache.platypus.server.grpc.LuceneServerTest.checkHits;
-import static org.apache.platypus.server.luceneserver.IndexState.BASE_BACKUP_PATH;
-import static org.apache.platypus.server.luceneserver.IndexState.BASE_STATE_BACKUP_PATH;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
 
 @RunWith(JUnit4.class)
 public class ReplicationTestFailureScenarios {
@@ -39,26 +44,41 @@ public class ReplicationTestFailureScenarios {
     @Rule
     public final TemporaryFolder folder = new TemporaryFolder();
 
+    private Path primaryStateDir;
     private GrpcServer luceneServerPrimary;
     private GrpcServer replicationServerPrimary;
 
     private GrpcServer luceneServerSecondary;
     private GrpcServer replicationServerSecondary;
 
+    private final String BUCKET_NAME = "archiver-unittest";
+    private Archiver archiver;
+    private S3Mock api;
+    private AmazonS3 s3;
+    private Path s3Directory;
+    private Path archiverDirectory;
+
     @After
     public void tearDown() throws IOException {
+        api.shutdown();
         luceneServerPrimary.getGlobalState().close();
         luceneServerSecondary.getGlobalState().close();
         rmDir(Paths.get(luceneServerPrimary.getRootDirName()));
         rmDir(Paths.get(luceneServerSecondary.getRootDirName()));
-        rmDir(BASE_STATE_BACKUP_PATH);
-        rmDir(BASE_BACKUP_PATH);
     }
 
     @Before
     public void setUp() throws IOException {
-        BASE_BACKUP_PATH.toFile().mkdir();
-        BASE_STATE_BACKUP_PATH.toFile().mkdir();
+        //setup S3 for backup/restore
+        s3Directory = folder.newFolder("s3").toPath();
+        archiverDirectory = folder.newFolder("archiver").toPath();
+        api = S3Mock.create(8011, s3Directory.toAbsolutePath().toString());
+        api.start();
+        s3 = new AmazonS3Client(new AnonymousAWSCredentials());
+        s3.setEndpoint("http://127.0.0.1:8011");
+        s3.createBucket(BUCKET_NAME);
+        archiver = new ArchiverImpl(s3, BUCKET_NAME, archiverDirectory, new TarImpl());
+
         startPrimaryServer(null);
         startSecondaryServer();
     }
@@ -73,11 +93,13 @@ public class ReplicationTestFailureScenarios {
         if (stateDir == null) {
             Path rootDirPrimary = folder.newFolder(rootDirNamePrimary).toPath();
             globalStatePrimary = new GlobalState(nodeNamePrimary, rootDirPrimary, "localhost", 9900, 9001);
+            this.primaryStateDir = rootDirPrimary;
         } else {
             globalStatePrimary = new GlobalState(nodeNamePrimary, stateDir, "localhost", 9900, 9001);
+            this.primaryStateDir = stateDir;
         }
-        luceneServerPrimary = new GrpcServer(grpcCleanup, folder, false, globalStatePrimary, nodeNamePrimary, testIndex, globalStatePrimary.getPort());
-        replicationServerPrimary = new GrpcServer(grpcCleanup, folder, true, globalStatePrimary, nodeNamePrimary, testIndex, 9001);
+        luceneServerPrimary = new GrpcServer(grpcCleanup, folder, false, globalStatePrimary, nodeNamePrimary, testIndex, globalStatePrimary.getPort(), archiver);
+        replicationServerPrimary = new GrpcServer(grpcCleanup, folder, true, globalStatePrimary, nodeNamePrimary, testIndex, 9001, archiver);
 
     }
 
@@ -89,13 +111,14 @@ public class ReplicationTestFailureScenarios {
         Path rootDirSecondary = folder.newFolder(rootDirNameSecondary).toPath();
         String testIndex = TEST_INDEX;
         GlobalState globalStateSecondary = new GlobalState(nodeNameSecondary, rootDirSecondary, "localhost", 9902, 9003);
-        luceneServerSecondary = new GrpcServer(grpcCleanup, folder, false, globalStateSecondary, nodeNameSecondary, testIndex, globalStateSecondary.getPort());
-        replicationServerSecondary = new GrpcServer(grpcCleanup, folder, true, globalStateSecondary, nodeNameSecondary, testIndex, 9003);
+        luceneServerSecondary = new GrpcServer(grpcCleanup, folder, false, globalStateSecondary, nodeNameSecondary, testIndex, globalStateSecondary.getPort(), archiver);
+        replicationServerSecondary = new GrpcServer(grpcCleanup, folder, true, globalStateSecondary, nodeNameSecondary, testIndex, 9003, archiver);
     }
 
     public void shutdownPrimaryServer() throws IOException {
         luceneServerPrimary.getGlobalState().close();
         rmDir(Paths.get(luceneServerPrimary.getRootDirName()));
+        rmDir(primaryStateDir);
         luceneServerPrimary.shutdown();
         replicationServerPrimary.shutdown();
 
@@ -152,9 +175,9 @@ public class ReplicationTestFailureScenarios {
         testServerPrimary.addDocuments();
         //both primary and replica should have 4 docs
         publishNRTAndValidateSearchResults(4);
-        //commit primary
-        luceneServerPrimary.getBlockingStub().commit(CommitRequest.newBuilder().setIndexName(TEST_INDEX).build());
-        //commit secondary
+        //backup primary
+        backupIndex();
+        //commit secondary state
         luceneServerSecondary.getBlockingStub().commit(CommitRequest.newBuilder().setIndexName(TEST_INDEX).build());
 
         //non-graceful primary shutdown (i.e. blow away index directory)
@@ -203,17 +226,14 @@ public class ReplicationTestFailureScenarios {
         GrpcServer.TestServer testServerPrimary = new GrpcServer.TestServer(luceneServerPrimary, true, Mode.PRIMARY);
         //add 2 docs to primary
         testServerPrimary.addDocuments();
-        //commit primary
-        luceneServerPrimary.getBlockingStub().commit(CommitRequest.newBuilder().setIndexName(TEST_INDEX).build());
-
-        //non-graceful primary shutdown (i.e. blow away index directory)
+        //backup index
+        backupIndex();
+        //non-graceful primary shutdown (i.e. blow away index and state directory)
         shutdownPrimaryServer();
         //start primary again with latest commit point
-        Path stateDir = BASE_STATE_BACKUP_PATH.resolve("0").resolve("4");
-        startPrimaryServer(stateDir);
+        startPrimaryServer(null);
         //startIndex Primary with primaryGen = 1
         testServerPrimary = new GrpcServer.TestServer(luceneServerPrimary, true, Mode.PRIMARY, 1, true);
-
         //add 2 docs to primary
         testServerPrimary.addDocuments();
 
@@ -234,7 +254,7 @@ public class ReplicationTestFailureScenarios {
     }
 
     @Test
-    public void primaryDurabilitySyncWithReplica() throws  IOException, InterruptedException {
+    public void primaryDurabilitySyncWithReplica() throws IOException, InterruptedException {
         //startIndex primary
         GrpcServer.TestServer testServerPrimary = new GrpcServer.TestServer(luceneServerPrimary, true, Mode.PRIMARY);
         //startIndex replica
@@ -243,29 +263,26 @@ public class ReplicationTestFailureScenarios {
         testServerPrimary.addDocuments();
         //both primary and replica should have 2 docs
         publishNRTAndValidateSearchResults(2);
-        //commit primary (with 2 docs)
-        luceneServerPrimary.getBlockingStub().commit(CommitRequest.newBuilder().setIndexName(TEST_INDEX).build());
-        //commit metadata state for secondary
+
+        //backupIndex (with 2 docs)
+        backupIndex();
+        //commit metadata state for secondary, since we wil reuse this upon startIndex
         luceneServerSecondary.getBlockingStub().commit(CommitRequest.newBuilder().setIndexName(TEST_INDEX).build());
 
-        //add 4 more docs to primary but dont commit, NRT is at 8 docs but commit point at 2 docs
+        //add 6 more docs to primary but dont commit, NRT is at 8 docs but commit point at 2 docs
         testServerPrimary.addDocuments();
         testServerPrimary.addDocuments();
         testServerPrimary.addDocuments();
         publishNRTAndValidateSearchResults(8);
 
-
-        File latestBackup = ShardState.remoteStateExists(BASE_STATE_BACKUP_PATH);
-        assertNotEquals(null, latestBackup);
-
         //non-graceful primary shutdown (i.e. blow away index directory and stateDir)
         shutdownPrimaryServer();
 
         //start primary again, download data from latest commit point
-        startPrimaryServer(latestBackup.toPath());
+        startPrimaryServer(null);
         //startIndex Primary with primaryGen = 1
         testServerPrimary = new GrpcServer.TestServer(luceneServerPrimary, true, Mode.PRIMARY, 1, true);
-        //stop and restart secondary to connect to "new" primary
+        //stop and restart secondary to connect to "new" primary,
         gracefullRestartSecondary();
         //add 2 more docs to primary
         testServerPrimary.addDocuments();
@@ -277,22 +294,18 @@ public class ReplicationTestFailureScenarios {
     public void primaryDurabilityWithMultipleCommits() throws IOException, InterruptedException {
         //startIndex primary
         GrpcServer.TestServer testServerPrimary = new GrpcServer.TestServer(luceneServerPrimary, true, Mode.PRIMARY);
-        for (int i = 0; i < 5; i++){
-            //add 2 docs to primary
+        for (int i = 0; i < 5; i++) {
+            //add 4 docs to primary
             testServerPrimary.addDocuments();
             testServerPrimary.addDocuments();
-            //commit primary
-            luceneServerPrimary.getBlockingStub().commit(CommitRequest.newBuilder().setIndexName(TEST_INDEX).build());
+            backupIndex();
         }
 
-        File latestBackup = ShardState.remoteStateExists(BASE_STATE_BACKUP_PATH);
-        assertNotEquals(null, latestBackup);
-
-        //non-graceful primary shutdown (i.e. blow away index directory)
+        //non-graceful primary shutdown (i.e. blow away index directory and stateDir)
         shutdownPrimaryServer();
 
         //start primary again, download data from latest commit point
-        startPrimaryServer(latestBackup.toPath());
+        startPrimaryServer(null);
         //startIndex Primary with primaryGen = 1
         testServerPrimary = new GrpcServer.TestServer(luceneServerPrimary, true, Mode.PRIMARY, 1, true);
 
@@ -370,7 +383,14 @@ public class ReplicationTestFailureScenarios {
         checkHits(secondHit);
     }
 
+    private void backupIndex() {
+        luceneServerPrimary.getBlockingStub().backupIndex(BackupIndexRequest.newBuilder()
+                .setIndexName("test_index")
+                .setServiceName("testservice")
+                .setResourceName("testresource")
+                .build()
+        );
 
 
-
+    }
 }

--- a/src/test/java/org/apache/platypus/server/utils/ArchiverTest.java
+++ b/src/test/java/org/apache/platypus/server/utils/ArchiverTest.java
@@ -120,6 +120,19 @@ public class ArchiverTest {
         assertEquals(true, TarImplTest.dirsMatch(actualDownloadDir.resolve(resource).toFile(), sourceDir.toFile()));
     }
 
+    @Test
+    public void testUploadDownload() throws IOException {
+        String service = "testservice";
+        String resource = "testresource";
+        Path sourceDir = createDirWithFiles(service, resource);
+        String versionHash = archiver.upload(service, resource, sourceDir);
+        archiver.blessVersion(service, resource, versionHash);
+        Path downloadPath = archiver.download(service, resource);
+        Path parentPath = downloadPath.getParent();
+        Path path = parentPath.resolve(versionHash);
+        assertEquals(true, path.toFile().exists());
+    }
+
     private Path createDirWithFiles(String service, String resource) throws IOException {
         Path serviceDir = Files.createDirectory(archiverDirectory.resolve(service));
         Path resourceDir = Files.createDirectory(serviceDir.resolve(resource));


### PR DESCRIPTION
Added backup endpoint to s3 and restore on startIndex for Primary and Standalone Mode. 
Fixed tests.
Removed older workaround for remote storage locally

1. Still need to figure out snapshot/restore of taxoDir for Primary mode.
2. Probably need to add some more replication tests now that we have a more concrete backup/restore implementattion