### PR TITLE
fix copy files test

### DIFF
--- a/src/test/java/org/apache/platypus/server/grpc/ReplicationServerTest.java
+++ b/src/test/java/org/apache/platypus/server/grpc/ReplicationServerTest.java
@@ -160,7 +160,7 @@ public class ReplicationServerTest {
             }
         }
         assertEquals(1, done);
-        assertTrue(0 < ongoing);
+        assertTrue(0 <= ongoing);
         assertEquals(0, failed);
     }
 


### PR DESCRIPTION
CopyFilesHandler can return a status of `done` without ever having to return `ongoing` if the copying is completed in less than the initial sleep which is 10ms. 
Thus the test was incorrect since we could potentially get done before ever getting back an ongoing status.