### PR TITLE
decide aws region for s3 endpoint depending on the bucket.

### DIFF
--- a/src/main/java/org/apache/platypus/LuceneServerModule.java
+++ b/src/main/java/org/apache/platypus/LuceneServerModule.java
@@ -49,7 +49,6 @@ import java.nio.file.Paths;
 import static org.apache.platypus.server.config.LuceneServerConfiguration.DEFAULT_BOTO_CFG_PATH;
 
 public class LuceneServerModule extends AbstractModule {
-
     private final String[] args;
 
     public LuceneServerModule(String[] args) {
@@ -74,8 +73,14 @@ public class LuceneServerModule extends AbstractModule {
             Path botoCfgPath = Paths.get(luceneServerConfiguration.getBotoCfgPath());
             final ProfilesConfigFile profilesConfigFile = new ProfilesConfigFile(botoCfgPath.toFile());
             final AWSCredentialsProvider awsCredentialsProvider = new ProfileCredentialsProvider(profilesConfigFile, "default");
-            return AmazonS3ClientBuilder.standard()
+            AmazonS3 s3ClientInterim = AmazonS3ClientBuilder.standard()
                     .withCredentials(awsCredentialsProvider).build();
+            String region = s3ClientInterim.getBucketLocation(luceneServerConfiguration.getBucketName());
+            String serviceEndpoint = String.format("s3.%s.amazonaws.com", region);
+            return AmazonS3ClientBuilder.standard()
+                    .withCredentials(awsCredentialsProvider)
+                    .withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(serviceEndpoint, region))
+                    .build();
         }
     }
 

--- a/src/main/java/org/apache/platypus/server/cli/Cmd.java
+++ b/src/main/java/org/apache/platypus/server/cli/Cmd.java
@@ -49,4 +49,11 @@ public class Cmd {
         return Integer.parseInt(port);
     }
 
+    @CommandLine.Option(names = {"-h", "--hostname"}, description = "host name of server to connect to", required = true)
+    private String hostname;
+
+    public String getHostname() {
+        return hostname;
+    }
+
 }

--- a/src/main/java/org/apache/platypus/server/grpc/LuceneServerClient.java
+++ b/src/main/java/org/apache/platypus/server/grpc/LuceneServerClient.java
@@ -19,7 +19,6 @@
 
 package org.apache.platypus.server.grpc;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.util.JsonFormat;
 import io.grpc.ManagedChannel;
@@ -28,7 +27,24 @@ import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
-import org.apache.platypus.server.cli.*;
+import org.apache.platypus.server.cli.AddDocumentsCommand;
+import org.apache.platypus.server.cli.BackupIndexCommand;
+import org.apache.platypus.server.cli.Cmd;
+import org.apache.platypus.server.cli.CommitCommand;
+import org.apache.platypus.server.cli.CreateIndexCommand;
+import org.apache.platypus.server.cli.DeleteAllDocumentsCommand;
+import org.apache.platypus.server.cli.DeleteDocumentsCommand;
+import org.apache.platypus.server.cli.DeleteIndexCommand;
+import org.apache.platypus.server.cli.GetCurrentSearcherVersion;
+import org.apache.platypus.server.cli.LiveSettingsCommand;
+import org.apache.platypus.server.cli.RefreshCommand;
+import org.apache.platypus.server.cli.RegisterFieldsCommand;
+import org.apache.platypus.server.cli.SearchCommand;
+import org.apache.platypus.server.cli.SettingsCommand;
+import org.apache.platypus.server.cli.StartIndexCommand;
+import org.apache.platypus.server.cli.StatsCommand;
+import org.apache.platypus.server.cli.StopIndexCommand;
+import org.apache.platypus.server.cli.WriteNRTPointCommand;
 import picocli.CommandLine;
 
 import java.io.IOException;
@@ -353,7 +369,7 @@ public class LuceneServerClient {
         String subCommandStr = cmdResult.subcommand().commandSpec().name();
         Object subCommand = cmdResult.subcommand().commandSpec().userObject();
         Cmd baseComand = (Cmd) cmdResult.commandSpec().userObject();
-        LuceneServerClient client = new LuceneServerClient("localhost", baseComand.getPort());
+        LuceneServerClient client = new LuceneServerClient(baseComand.getHostname(), baseComand.getPort());
         try {
             String jsonStr = "";
             Path filePath;
@@ -442,6 +458,7 @@ public class LuceneServerClient {
                 case BACKUP_INDEX:
                     BackupIndexCommand backupIndexCommand = (BackupIndexCommand) subCommand;
                     client.backupIndex(backupIndexCommand.getIndexName(), backupIndexCommand.getServiceName(), backupIndexCommand.getResourceName());
+                    break;
                 default:
                     logger.warning(String.format("%s is not a valid server command", subCommandStr));
             }


### PR DESCRIPTION
Sometimes particularly dev/test environments we might have a bucket only in one region, but we still want nrtSearch running in other regions to be able to upload/download data from these buckets. 

This change allows us to do that but setting Endpoint.
Also added small fixes to BackupIndexCommand

Tested backup/restore in dev environment from various regions.