### PR TITLE
concurrent multipart s3 upload/download, lz4 compression, client tool for json input

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ def s3mockVersion = '0.2.5'
 def commonsCompressVersion = '1.19'
 def awsJavaSdkVersion = '1.11.695'
 def guicedeeVersion = '1.0.1.7-jre13'
+def lz4Version = '1.7.0'
 
 dependencies {
     //grpc deps
@@ -55,6 +56,7 @@ dependencies {
     implementation "com.amazonaws:aws-java-sdk-core:${awsJavaSdkVersion}"
     implementation "com.amazonaws:aws-java-sdk-s3:${awsJavaSdkVersion}"
     implementation "com.guicedee.services:guice:${guicedeeVersion}"
+    implementation "org.lz4:lz4-java:${lz4Version}"
 
     //lucene deps
     implementation "org.apache.lucene:lucene-core:${luceneVersion}"

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ targetCompatibility = 1.12
 
 // Feel free to delete the comment at the next line. It is just for safely
 // updating the version in our release process.
-def grpcVersion = '1.23.0' // CURRENT_GRPC_VERSION
+def grpcVersion = '1.26.0' // CURRENT_GRPC_VERSION
 def protobufVersion = '3.9.0'
 def protocVersion = protobufVersion
 def luceneVersion = '8.2.0'

--- a/src/main/java/org/apache/platypus/LuceneServerModule.java
+++ b/src/main/java/org/apache/platypus/LuceneServerModule.java
@@ -55,9 +55,11 @@ public class LuceneServerModule extends AbstractModule {
         this.args = args;
     }
 
-    @Override
-    public void configure() {
-        bind(Tar.class).to(TarImpl.class);
+    @Inject
+    @Singleton
+    @Provides
+    public Tar providesTar() {
+        return new TarImpl(Tar.CompressionMode.LZ4);
     }
 
     @Inject
@@ -87,9 +89,9 @@ public class LuceneServerModule extends AbstractModule {
     @Inject
     @Singleton
     @Provides
-    protected Archiver providesArchiver(LuceneServerConfiguration luceneServerConfiguration, AmazonS3 amazonS3) {
+    protected Archiver providesArchiver(LuceneServerConfiguration luceneServerConfiguration, AmazonS3 amazonS3, Tar tar) {
         Path archiveDir = Paths.get(luceneServerConfiguration.getArchiveDirectory());
-        return new ArchiverImpl(amazonS3, luceneServerConfiguration.getBucketName(), archiveDir, new TarImpl());
+        return new ArchiverImpl(amazonS3, luceneServerConfiguration.getBucketName(), archiveDir, tar);
     }
 
     @Inject

--- a/src/main/java/org/apache/platypus/server/cli/AddDocumentsCommand.java
+++ b/src/main/java/org/apache/platypus/server/cli/AddDocumentsCommand.java
@@ -28,11 +28,18 @@ import static org.apache.platypus.server.cli.AddDocumentsCommand.ADD_DOCUMENTS;
 public class AddDocumentsCommand {
     public static final String ADD_DOCUMENTS = "addDocuments";
 
-    @CommandLine.Option(names = {"-f", "--fileName"}, description = "documents to be added in a csv format. First row has names of fields and rows after are values", required = true)
+    @CommandLine.Option(names = {"-f", "--fileName"}, description = "documents to be added in a csv or json format. For csv first row has names of fields and rows after are values", required = true)
     private String fileName;
 
     public String getFileName() {
         return fileName;
+    }
+
+    @CommandLine.Option(names = {"-t", "--fileType"}, description = "type of input file", required = true)
+    private String fileType;
+
+    public String getFileType() {
+        return fileType;
     }
 
     @CommandLine.Option(names = {"-i", "--indexName"}, description = "name of the index to add documents to", required = true)
@@ -40,6 +47,13 @@ public class AddDocumentsCommand {
 
     public String getIndexName() {
         return indexName;
+    }
+
+    @CommandLine.Option(names = {"-l", "--maxBufferLen"}, description = "num Docs to batch up as one stream sent to the  server", defaultValue = "100")
+    private String maxBufferLen;
+
+    public int getMaxBufferLen() {
+        return Integer.parseInt(maxBufferLen);
     }
 
 }

--- a/src/main/java/org/apache/platypus/server/grpc/LuceneServer.java
+++ b/src/main/java/org/apache/platypus/server/grpc/LuceneServer.java
@@ -342,7 +342,7 @@ public class LuceneServer {
                             pq.offer(gen);
                         }
                         long t1 = System.nanoTime();
-
+                        finishIndexingJob();
                         responseObserver.onNext(AddDocumentResponse.newBuilder().setGenId(String.valueOf(pq.peek())).build());
                         responseObserver.onCompleted();
                         logger.info(String.format("Indexing job completed for %s docs, in %s chunks, with latest sequence number: %s, took: %s micro seconds",
@@ -361,6 +361,12 @@ public class LuceneServer {
                         count = 0;
                     }
 
+                }
+
+                private void finishIndexingJob() throws IOException {
+                    for (String indexName : globalState.getIndexNames()) {
+                        globalState.getIndex(indexName).getShard(0).maybeRefreshBlocking();
+                    }
                 }
             };
         }

--- a/src/main/java/org/apache/platypus/server/grpc/LuceneServer.java
+++ b/src/main/java/org/apache/platypus/server/grpc/LuceneServer.java
@@ -298,11 +298,11 @@ public class LuceneServer {
 
                 @Override
                 public void onNext(AddDocumentRequest addDocumentRequest) {
-                    logger.info(String.format("onNext, addDocumentRequestQueue size: %s", addDocumentRequestQueue.size()));
+                    logger.debug(String.format("onNext, addDocumentRequestQueue size: %s", addDocumentRequestQueue.size()));
                     count++;
                     addDocumentRequestQueue.add(addDocumentRequest);
                     if (addDocumentRequestQueue.size() == MAX_BUFFER_LEN) {
-                        logger.info(String.format("indexing addDocumentRequestQueue of size: %s", addDocumentRequestQueue.size()));
+                        logger.info(String.format("indexing addDocumentRequestQueue size: %s, total: %s", addDocumentRequestQueue.size(), count));
                         try {
                             List<AddDocumentRequest> addDocRequestList = addDocumentRequestQueue.stream().collect(Collectors.toList());
                             Future<Long> future = globalState.submitIndexingTask(new AddDocumentHandler.DocumentIndexer(globalState, addDocRequestList));
@@ -869,7 +869,7 @@ public class LuceneServer {
             try {
                 IndexState indexState = globalState.getIndex(request.getIndexName());
                 CopyState reply = new RecvCopyStateHandler().handle(indexState, request);
-                logger.info("AddReplicaHandler returned " + reply.toString());
+                logger.debug("RecvCopyStateHandler returned, completedMergeFiles count: " + reply.getCompletedMergeFilesCount());
                 responseObserver.onNext(reply);
                 responseObserver.onCompleted();
             } catch (Exception e) {

--- a/src/main/java/org/apache/platypus/server/luceneserver/CopyFilesHandler.java
+++ b/src/main/java/org/apache/platypus/server/luceneserver/CopyFilesHandler.java
@@ -70,7 +70,7 @@ public class CopyFilesHandler implements Handler<CopyFiles, TransferStatus> {
                 responseObserver.onNext(TransferStatus.newBuilder().setMessage("replica is copying files..." + files.keySet()).setCode(TransferStatusCode.Ongoing).build());
             } catch (InterruptedException e) {
                 responseObserver.onNext(TransferStatus.newBuilder().setMessage(String.format("replica failed to copy files..." + files.keySet())).setCode(TransferStatusCode.Failed).build());
-                //called must set; //responseObserver.onError(e);
+                //caller must set; //responseObserver.onError(e);
                 throw new RuntimeException(e);
             }
         }

--- a/src/main/java/org/apache/platypus/server/luceneserver/GlobalState.java
+++ b/src/main/java/org/apache/platypus/server/luceneserver/GlobalState.java
@@ -28,6 +28,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
+import java.util.Collections;
+import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -268,6 +270,10 @@ public class GlobalState implements Closeable, Restorable {
 
     public int getReplicationPort() {
         return replicationPort;
+    }
+
+    public Set<String> getIndexNames() {
+        return Collections.unmodifiableSet(indices.keySet());
     }
 
 }

--- a/src/main/java/org/apache/platypus/server/luceneserver/SearchHandler.java
+++ b/src/main/java/org/apache/platypus/server/luceneserver/SearchHandler.java
@@ -540,6 +540,7 @@ public class SearchHandler implements Handler<SearchRequest, SearchResponse> {
                                 state.release(current);
                                 cond.await();
                                 current = state.acquire();
+                                logger.info("SearchHandler: await released,  current version " + ((DirectoryReader) current.searcher.getIndexReader()).getVersion() + " required minimum version "+ version);
                                 assert ((DirectoryReader) current.searcher.getIndexReader()).getVersion() >= version;
                             }
                             s = current;

--- a/src/main/java/org/apache/platypus/server/utils/Tar.java
+++ b/src/main/java/org/apache/platypus/server/utils/Tar.java
@@ -30,9 +30,19 @@ import java.nio.file.Path;
 
 public interface Tar {
     void extractTar(Path sourceFile, Path destDir) throws IOException;
+
     void extractTar(final TarArchiveInputStream tarArchiveInputStream, final Path destDirectory) throws IOException;
 
     void buildTar(Path sourceDir, Path destinationFile) throws IOException;
+
     void buildTar(TarArchiveOutputStream tarArchiveOutputStream, Path sourceDir) throws IOException;
+
+    CompressionMode getCompressionMode();
+
+    enum CompressionMode {
+        GZIP,
+        LZ4
+    }
+
 
 }

--- a/src/main/java/org/apache/platypus/server/utils/TarImpl.java
+++ b/src/main/java/org/apache/platypus/server/utils/TarImpl.java
@@ -23,6 +23,8 @@
 package org.apache.platypus.server.utils;
 
 import com.google.inject.Inject;
+import net.jpountz.lz4.LZ4FrameInputStream;
+import net.jpountz.lz4.LZ4FrameOutputStream;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
@@ -31,28 +33,35 @@ import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
 import org.apache.commons.io.IOUtils;
 
 import java.io.BufferedInputStream;
-import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 
 public class TarImpl implements Tar {
-    @Inject
-    public TarImpl() {
+    private final CompressionMode compressionMode;
 
+    @Inject
+    public TarImpl(CompressionMode compressionMode) {
+        this.compressionMode = compressionMode;
     }
 
     @Override
     public void extractTar(Path sourceFile, Path destDir) throws IOException {
+        final FileInputStream fileInputStream = new FileInputStream(sourceFile.toFile());
+        final InputStream compressorInputStream;
+        if (compressionMode.equals(CompressionMode.LZ4)) {
+            compressorInputStream = new LZ4FrameInputStream(fileInputStream);
+        } else {
+            compressorInputStream = new GzipCompressorInputStream(fileInputStream, true);
+        }
         try (
-                final FileInputStream fileInputStream = new FileInputStream(sourceFile.toFile());
-                final GzipCompressorInputStream gzipCompressorInputStream = new GzipCompressorInputStream(fileInputStream, true);
-                final TarArchiveInputStream tarArchiveInputStream = new TarArchiveInputStream(gzipCompressorInputStream);
-
+                final TarArchiveInputStream tarArchiveInputStream = new TarArchiveInputStream(compressorInputStream);
         ) {
             extractTar(tarArchiveInputStream, destDir);
         }
@@ -91,10 +100,15 @@ public class TarImpl implements Tar {
 
     @Override
     public void buildTar(Path sourceDir, Path destinationFile) throws IOException {
+        final FileOutputStream fileOutputStream = new FileOutputStream(destinationFile.toFile());
+        final OutputStream compressorOutputStream;
+        if (compressionMode.equals(CompressionMode.LZ4)) {
+            compressorOutputStream = new LZ4FrameOutputStream(fileOutputStream);
+        } else {
+            compressorOutputStream = new GzipCompressorOutputStream(fileOutputStream);
+        }
         try (
-                final FileOutputStream fileOutputStream = new FileOutputStream(destinationFile.toFile());
-                final GzipCompressorOutputStream gzipCompressorOutputStream = new GzipCompressorOutputStream(fileOutputStream);
-                final TarArchiveOutputStream tarArchiveOutputStream = new TarArchiveOutputStream(gzipCompressorOutputStream)) {
+                final TarArchiveOutputStream tarArchiveOutputStream = new TarArchiveOutputStream(compressorOutputStream)) {
             buildTar(tarArchiveOutputStream, sourceDir);
         }
     }
@@ -105,6 +119,11 @@ public class TarImpl implements Tar {
             throw new IOException("source directory doesn't exist: " + sourceDir);
         }
         addFilestoTarGz(sourceDir.toString(), "", tarArchiveOutputStream);
+    }
+
+    @Override
+    public CompressionMode getCompressionMode() {
+        return compressionMode;
     }
 
     private static void addFilestoTarGz(String filePath, String parent, TarArchiveOutputStream tarArchiveOutputStream) throws IOException {
@@ -126,4 +145,30 @@ public class TarImpl implements Tar {
             }
         }
     }
+
+    public static void main(String[] args) throws IOException {
+        //lz4
+        TarImpl lz4Tar = new TarImpl(Tar.CompressionMode.LZ4);
+        long t1 = System.nanoTime();
+        lz4Tar.buildTar(Paths.get(args[0]), Paths.get(args[1] + ".lz4"));
+        long t2 = System.nanoTime();
+        System.out.println("buildTar with lz4 took " + (t2 - t1) / (1000 * 1000 * 1000) + " seconds");
+
+        lz4Tar.extractTar(Paths.get(args[1] + ".lz4"), Paths.get(args[0], "lz4"));
+        long t3 = System.nanoTime();
+        System.out.println("extractTar with lz4 took " + (t3 - t2) / (1000 * 1000 * 1000) + " seconds");
+
+        //gzip
+        TarImpl gzipTar = new TarImpl(Tar.CompressionMode.GZIP);
+        t1 = System.nanoTime();
+        gzipTar.buildTar(Paths.get(args[0]), Paths.get(args[1] + ".gzip"));
+        t2 = System.nanoTime();
+        System.out.println("buildTar with with gzip took " + (t2 - t1) / (1000 * 1000 * 1000) + " seconds");
+
+        gzipTar.extractTar(Paths.get(args[1] + ".gzip"), Paths.get(args[0], "gzip"));
+        t3 = System.nanoTime();
+        System.out.println("extractTar with gzip took " + (t3 - t2) / (1000 * 1000 * 1000) + " seconds");
+
+    }
+
 }

--- a/src/main/java/org/apache/platypus/server/utils/TarImpl.java
+++ b/src/main/java/org/apache/platypus/server/utils/TarImpl.java
@@ -146,29 +146,4 @@ public class TarImpl implements Tar {
         }
     }
 
-    public static void main(String[] args) throws IOException {
-        //lz4
-        TarImpl lz4Tar = new TarImpl(Tar.CompressionMode.LZ4);
-        long t1 = System.nanoTime();
-        lz4Tar.buildTar(Paths.get(args[0]), Paths.get(args[1] + ".lz4"));
-        long t2 = System.nanoTime();
-        System.out.println("buildTar with lz4 took " + (t2 - t1) / (1000 * 1000 * 1000) + " seconds");
-
-        lz4Tar.extractTar(Paths.get(args[1] + ".lz4"), Paths.get(args[0], "lz4"));
-        long t3 = System.nanoTime();
-        System.out.println("extractTar with lz4 took " + (t3 - t2) / (1000 * 1000 * 1000) + " seconds");
-
-        //gzip
-        TarImpl gzipTar = new TarImpl(Tar.CompressionMode.GZIP);
-        t1 = System.nanoTime();
-        gzipTar.buildTar(Paths.get(args[0]), Paths.get(args[1] + ".gzip"));
-        t2 = System.nanoTime();
-        System.out.println("buildTar with with gzip took " + (t2 - t1) / (1000 * 1000 * 1000) + " seconds");
-
-        gzipTar.extractTar(Paths.get(args[1] + ".gzip"), Paths.get(args[0], "gzip"));
-        t3 = System.nanoTime();
-        System.out.println("extractTar with gzip took " + (t3 - t2) / (1000 * 1000 * 1000) + " seconds");
-
-    }
-
 }

--- a/src/test/java/org/apache/platypus/server/grpc/BackupRestoreIndexRequestHandlerTest.java
+++ b/src/test/java/org/apache/platypus/server/grpc/BackupRestoreIndexRequestHandlerTest.java
@@ -33,6 +33,7 @@ import org.apache.platypus.server.config.LuceneServerConfiguration;
 import org.apache.platypus.server.luceneserver.GlobalState;
 import org.apache.platypus.server.utils.Archiver;
 import org.apache.platypus.server.utils.ArchiverImpl;
+import org.apache.platypus.server.utils.Tar;
 import org.apache.platypus.server.utils.TarImpl;
 import org.iq80.leveldb.util.FileUtils;
 import org.junit.After;
@@ -85,7 +86,7 @@ public class BackupRestoreIndexRequestHandlerTest {
         s3 = new AmazonS3Client(new AnonymousAWSCredentials());
         s3.setEndpoint("http://127.0.0.1:8011");
         s3.createBucket(BUCKET_NAME);
-        archiver = new ArchiverImpl(s3, BUCKET_NAME, archiverDirectory, new TarImpl());
+        archiver = new ArchiverImpl(s3, BUCKET_NAME, archiverDirectory, new TarImpl(Tar.CompressionMode.LZ4));
         grpcServer = setUpGrpcServer();
     }
 

--- a/src/test/java/org/apache/platypus/server/grpc/GrpcServer.java
+++ b/src/test/java/org/apache/platypus/server/grpc/GrpcServer.java
@@ -1,6 +1,5 @@
 package org.apache.platypus.server.grpc;
 
-import com.amazonaws.services.s3.AmazonS3;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.util.JsonFormat;
 import io.grpc.ManagedChannel;
@@ -14,8 +13,6 @@ import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.platypus.server.luceneserver.GlobalState;
 import org.apache.platypus.server.utils.Archiver;
-import org.apache.platypus.server.utils.ArchiverImpl;
-import org.apache.platypus.server.utils.TarImpl;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.IOException;

--- a/src/test/java/org/apache/platypus/server/grpc/GrpcServer.java
+++ b/src/test/java/org/apache/platypus/server/grpc/GrpcServer.java
@@ -1,5 +1,6 @@
 package org.apache.platypus.server.grpc;
 
+import com.amazonaws.services.s3.AmazonS3;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.protobuf.util.JsonFormat;
 import io.grpc.ManagedChannel;
@@ -13,6 +14,8 @@ import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.platypus.server.luceneserver.GlobalState;
 import org.apache.platypus.server.utils.Archiver;
+import org.apache.platypus.server.utils.ArchiverImpl;
+import org.apache.platypus.server.utils.TarImpl;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.IOException;
@@ -174,7 +177,6 @@ public class GrpcServer {
             }
         }
     }
-
 
     public static class TestServer {
         private final GrpcServer grpcServer;

--- a/src/test/java/org/apache/platypus/server/grpc/LuceneServerClientBuilderTest.java
+++ b/src/test/java/org/apache/platypus/server/grpc/LuceneServerClientBuilderTest.java
@@ -1,0 +1,61 @@
+/*
+ *
+ *  *
+ *  *  Copyright 2019 Yelp Inc.
+ *  *
+ *  *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  *  you may not use this file except in compliance with the License.
+ *  *  You may obtain a copy of the License at
+ *  *       http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  *  Unless required by applicable law or agreed to in writing, software
+ *  *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ *  *  either express or implied.
+ *  *  See the License for the specific language governing permissions and
+ *  *  limitations under the License.
+ *  *
+ *  *
+ *
+ *
+ */
+
+package org.apache.platypus.server.grpc;
+
+import com.google.gson.Gson;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.junit.Assert.*;
+
+public class LuceneServerClientBuilderTest {
+
+    @Test
+    public void buildRequest() throws IOException {
+        Path filePath = Paths.get("src", "test", "resources", "addDocs.txt");
+        int maxBufferLen = 10;
+        LuceneServerClientBuilder.AddJsonDocumentsClientBuilder addJsonDocumentsClientBuilder =
+                new LuceneServerClientBuilder.AddJsonDocumentsClientBuilder("test_index", new Gson(), filePath, maxBufferLen);
+        Stream<AddDocumentRequest> addDocumentRequestStream = addJsonDocumentsClientBuilder.buildRequest(filePath);
+        List<AddDocumentRequest> addDocumentRequestList = addDocumentRequestStream.collect(Collectors.toList());
+        AddDocumentRequest firstDoc = addDocumentRequestList.get(0);
+        assertEquals("test_index", firstDoc.getIndexName());
+        assertEquals("first vendor", firstDoc.getFieldsMap().get("vendor_name").getValue(0));
+        assertEquals("first again", firstDoc.getFieldsMap().get("vendor_name").getValue(1));
+        assertEquals("3", firstDoc.getFieldsMap().get("count").getValue(0));
+        AddDocumentRequest secondDoc = addDocumentRequestList.get(1);
+        assertEquals("test_index", secondDoc.getIndexName());
+        assertEquals("second vendor", secondDoc.getFieldsMap().get("vendor_name").getValue(0));
+        assertEquals("second again", secondDoc.getFieldsMap().get("vendor_name").getValue(1));
+        assertEquals("7", secondDoc.getFieldsMap().get("count").getValue(0));
+
+    }
+
+
+}

--- a/src/test/java/org/apache/platypus/server/grpc/LuceneServerTest.java
+++ b/src/test/java/org/apache/platypus/server/grpc/LuceneServerTest.java
@@ -143,9 +143,7 @@ public class LuceneServerTest {
         assertEquals(2, statsResponse.getNumDocs());
         assertEquals(2, statsResponse.getMaxDoc());
         assertEquals(0, statsResponse.getOrd());
-        //searcher is not refreshed so searcher returns zeroDocs
-        //Note: (does refresh in background thread eventually every indexState.indexMaxRefreshSec)
-        assertEquals(0, statsResponse.getCurrentSearcher().getNumDocs());
+        assertEquals(2, statsResponse.getCurrentSearcher().getNumDocs());
         assertEquals("started", statsResponse.getState());
     }
 
@@ -156,11 +154,7 @@ public class LuceneServerTest {
         assertEquals(2, statsResponse.getNumDocs());
         assertEquals(2, statsResponse.getMaxDoc());
         assertEquals(0, statsResponse.getOrd());
-        //searcher is not refreshed so searcher returns zeroDocs
-        //Note: (does refresh in background thread eventually every indexState.indexMaxRefreshSec)
-        assertEquals(0, statsResponse.getCurrentSearcher().getNumDocs());
-        //manual refresh
-        grpcServer.getBlockingStub().refresh(RefreshRequest.newBuilder().setIndexName(grpcServer.getTestIndex()).build());
+        assertEquals(2, statsResponse.getCurrentSearcher().getNumDocs());
         //check status on currentSearchAgain
         statsResponse = grpcServer.getBlockingStub().stats(StatsRequest.newBuilder().setIndexName(grpcServer.getTestIndex()).build());
         assertEquals(2, statsResponse.getCurrentSearcher().getNumDocs());

--- a/src/test/java/org/apache/platypus/server/grpc/ReplicationServerTest.java
+++ b/src/test/java/org/apache/platypus/server/grpc/ReplicationServerTest.java
@@ -10,6 +10,7 @@ import org.apache.platypus.server.config.LuceneServerConfiguration;
 import org.apache.platypus.server.luceneserver.GlobalState;
 import org.apache.platypus.server.utils.Archiver;
 import org.apache.platypus.server.utils.ArchiverImpl;
+import org.apache.platypus.server.utils.Tar;
 import org.apache.platypus.server.utils.TarImpl;
 import org.junit.After;
 import org.junit.Before;
@@ -78,7 +79,7 @@ public class ReplicationServerTest {
         s3 = new AmazonS3Client(new AnonymousAWSCredentials());
         s3.setEndpoint("http://127.0.0.1:8011");
         s3.createBucket(BUCKET_NAME);
-        archiver = new ArchiverImpl(s3, BUCKET_NAME, archiverDirectory, new TarImpl());
+        archiver = new ArchiverImpl(s3, BUCKET_NAME, archiverDirectory, new TarImpl(Tar.CompressionMode.LZ4));
 
         //set up primary servers
         String testIndex = "test_index";

--- a/src/test/java/org/apache/platypus/server/grpc/ReplicationTestFailureScenarios.java
+++ b/src/test/java/org/apache/platypus/server/grpc/ReplicationTestFailureScenarios.java
@@ -99,7 +99,7 @@ public class ReplicationTestFailureScenarios {
         luceneServerSecondary = new GrpcServer(grpcCleanup, folder, false, globalStateSecondary,
                 luceneSecondaryConfiguration.getIndexDir(), TEST_INDEX, globalStateSecondary.getPort(), archiver);
         replicationServerSecondary = new GrpcServer(grpcCleanup, folder, true, globalStateSecondary,
-                luceneSecondaryConfiguration.getIndexDir(), TEST_INDEX, 9003, archiver);
+                luceneSecondaryConfiguration.getIndexDir(), TEST_INDEX, globalStateSecondary.getReplicationPort(), archiver);
     }
 
     public void shutdownPrimaryServer() throws IOException {

--- a/src/test/java/org/apache/platypus/server/grpc/ReplicationTestFailureScenarios.java
+++ b/src/test/java/org/apache/platypus/server/grpc/ReplicationTestFailureScenarios.java
@@ -10,6 +10,7 @@ import org.apache.platypus.server.config.LuceneServerConfiguration;
 import org.apache.platypus.server.luceneserver.GlobalState;
 import org.apache.platypus.server.utils.Archiver;
 import org.apache.platypus.server.utils.ArchiverImpl;
+import org.apache.platypus.server.utils.Tar;
 import org.apache.platypus.server.utils.TarImpl;
 import org.junit.After;
 import org.junit.Before;
@@ -75,7 +76,7 @@ public class ReplicationTestFailureScenarios {
         s3 = new AmazonS3Client(new AnonymousAWSCredentials());
         s3.setEndpoint("http://127.0.0.1:8011");
         s3.createBucket(BUCKET_NAME);
-        archiver = new ArchiverImpl(s3, BUCKET_NAME, archiverDirectory, new TarImpl());
+        archiver = new ArchiverImpl(s3, BUCKET_NAME, archiverDirectory, new TarImpl(Tar.CompressionMode.LZ4));
 
         startPrimaryServer();
         startSecondaryServer();

--- a/src/test/java/org/apache/platypus/server/utils/TarImplTest.java
+++ b/src/test/java/org/apache/platypus/server/utils/TarImplTest.java
@@ -159,4 +159,28 @@ public class TarImplTest {
         }
     }
 
+    public static void main(String[] args) throws IOException {
+        //lz4
+        TarImpl lz4Tar = new TarImpl(Tar.CompressionMode.LZ4);
+        long t1 = System.nanoTime();
+        lz4Tar.buildTar(Paths.get(args[0]), Paths.get(args[1] + ".lz4"));
+        long t2 = System.nanoTime();
+        System.out.println("buildTar with lz4 took " + (t2 - t1) / (1000 * 1000 * 1000) + " seconds");
+
+        lz4Tar.extractTar(Paths.get(args[1] + ".lz4"), Paths.get(args[0], "lz4"));
+        long t3 = System.nanoTime();
+        System.out.println("extractTar with lz4 took " + (t3 - t2) / (1000 * 1000 * 1000) + " seconds");
+
+        //gzip
+        TarImpl gzipTar = new TarImpl(Tar.CompressionMode.GZIP);
+        t1 = System.nanoTime();
+        gzipTar.buildTar(Paths.get(args[0]), Paths.get(args[1] + ".gzip"));
+        t2 = System.nanoTime();
+        System.out.println("buildTar with with gzip took " + (t2 - t1) / (1000 * 1000 * 1000) + " seconds");
+
+        gzipTar.extractTar(Paths.get(args[1] + ".gzip"), Paths.get(args[0], "gzip"));
+        t3 = System.nanoTime();
+        System.out.println("extractTar with gzip took " + (t3 - t2) / (1000 * 1000 * 1000) + " seconds");
+
+    }
 }

--- a/src/test/java/org/apache/platypus/server/utils/TarImplTest.java
+++ b/src/test/java/org/apache/platypus/server/utils/TarImplTest.java
@@ -23,12 +23,11 @@
 package org.apache.platypus.server.utils;
 
 import com.amazonaws.util.IOUtils;
+import net.jpountz.lz4.LZ4FrameInputStream;
+import net.jpountz.lz4.LZ4FrameOutputStream;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
-import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
-import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -43,7 +42,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.security.MessageDigest;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 
@@ -67,7 +66,7 @@ public class TarImplTest {
 
     @Test
     public void extractTar() throws IOException {
-        Path sourceTarFile = tarTestBaseDirectory.resolve("test_tar.tar.gz");
+        Path sourceTarFile = tarTestBaseDirectory.resolve("test_tar.tar.lz4");
         Path destDir = tarTestBaseDirectory.resolve("extractedDir");
         try (
                 final FileOutputStream fileOutputStream = new FileOutputStream(sourceTarFile.toFile());
@@ -75,7 +74,7 @@ public class TarImplTest {
             byte[] tarContent = getTarFile(Arrays.asList(tarEntry1, tarEntry2));
             fileOutputStream.write(tarContent);
         }
-        new TarImpl().extractTar(sourceTarFile, destDir);
+        new TarImpl(TarImpl.CompressionMode.LZ4).extractTar(sourceTarFile, destDir);
 
         assertEquals(Files.readAllLines(destDir.resolve("foo")).get(0), tarEntry1.content);
         assertEquals(Files.readAllLines(destDir.resolve("bar").resolve("baz")).get(0), tarEntry2.content);
@@ -95,15 +94,15 @@ public class TarImplTest {
             IOUtils.copy(test2content, fileOutputStream2);
         }
         Path destTarFile = tarTestBaseDirectory.resolve("result.tar.gz");
-        new TarImpl().buildTar(sourceDir, destTarFile);
+        new TarImpl(TarImpl.CompressionMode.LZ4).buildTar(sourceDir, destTarFile);
 
         try (
                 final FileInputStream fileInputStream = new FileInputStream(destTarFile.toFile());
-                final GzipCompressorInputStream gzipCompressorInputStream = new GzipCompressorInputStream(fileInputStream, true);
-                final TarArchiveInputStream tarArchiveInputStream = new TarArchiveInputStream(gzipCompressorInputStream);
+                final LZ4FrameInputStream compressorInputStream = new LZ4FrameInputStream(fileInputStream);
+                final TarArchiveInputStream tarArchiveInputStream = new TarArchiveInputStream(compressorInputStream);
         ) {
             Path destDir = tarTestBaseDirectory.resolve("test_extract");
-            new TarImpl().extractTar(tarArchiveInputStream, destDir);
+            new TarImpl(TarImpl.CompressionMode.LZ4).extractTar(tarArchiveInputStream, destDir);
             assertEquals(true, dirsMatch(sourceDir.toFile(), destDir.resolve("dirToTar").toFile()));
 
         }
@@ -133,8 +132,8 @@ public class TarImplTest {
     byte[] getTarFile(List<TarEntry> tarEntries) throws IOException {
         try (
                 final ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-                final GzipCompressorOutputStream gzipCompressorOutputStream = new GzipCompressorOutputStream(byteArrayOutputStream);
-                final TarArchiveOutputStream tarArchiveOutputStream = new TarArchiveOutputStream(gzipCompressorOutputStream);
+                final LZ4FrameOutputStream compressorOutputStream = new LZ4FrameOutputStream(byteArrayOutputStream);
+                final TarArchiveOutputStream tarArchiveOutputStream = new TarArchiveOutputStream(compressorOutputStream);
         ) {
             for (final TarEntry tarEntry : tarEntries) {
                 final byte[] data = tarEntry.content.getBytes(StandardCharsets.UTF_8);

--- a/src/test/resources/addDocs.txt
+++ b/src/test/resources/addDocs.txt
@@ -1,0 +1,2 @@
+{"doc_id": 1, "vendor_name": ["first vendor", "first again"], "vendor_name_atom":["first atom vendor", "first atom again" ], "license_no": [300, 3100], "count": 3 }
+{"doc_id": 2, "vendor_name": ["second vendor", "second again"], "vendor_name_atom":["second atom vendor", "second atom again" ], "license_no": [411, 4222], "count": 7 }


### PR DESCRIPTION
* client tool can now accept indexing docs from json files, 1 json doc per line
* use lz4 for compression
* multipart s3 upload and parallel s3 download

lz4 vs gzip speed comparisons for a 12G index.

```
umesh@devbox:~$ ls -ltrh /nail/home/umesh/nrtsearch/compressed.*
-rw-r--r-- 1 umesh users 9.4G Feb 21 12:26 /nail/home/umesh/nrtsearch/compressed.lz4
-rw-r--r-- 1 umesh users 7.5G Feb 21 12:40 /nail/home/umesh/nrtsearch/compressed.gzip
umesh@devbox:~$ du -sh /nail/home/umesh/nrtsearch/primary_index/
12G     /nail/home/umesh/nrtsearch/primary_index/
umesh@devbox:~/pg/platypus (client_add_docs_from_json_files) $ ./tar_impl.sh
buildTar with lz4 took 37 seconds
buildTar with gzip took 848 seconds
umesh@devbox:~/pg/platypus (client_add_docs_from_json_files) $ ./tar_extract_impl.sh
extractTar with lz4 took 59 seconds
extractTar with gzip took 105 seconds
```

* parallel s3 upload took around ~3 mins for 12G index
* parallel s3 download takes around ~10seconds per GB of data