### PR TITLE
default to use MMapDirectory and preload mapped pages into memory on init

### DIFF
--- a/src/main/java/org/apache/platypus/server/luceneserver/DirectoryFactory.java
+++ b/src/main/java/org/apache/platypus/server/luceneserver/DirectoryFactory.java
@@ -18,7 +18,13 @@
  */
 
 package org.apache.platypus.server.luceneserver;
-import org.apache.lucene.store.*;
+
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.FSDirectory;
+import org.apache.lucene.store.MMapDirectory;
+import org.apache.lucene.store.NIOFSDirectory;
+import org.apache.lucene.store.RAMDirectory;
+import org.apache.lucene.store.SimpleFSDirectory;
 
 import java.io.IOException;
 import java.lang.reflect.Constructor;
@@ -61,7 +67,9 @@ public abstract class DirectoryFactory {
             return new DirectoryFactory() {
                 @Override
                 public Directory open(Path path) throws IOException {
-                    return new MMapDirectory(path);
+                    MMapDirectory mMapDirectory = new MMapDirectory(path);
+                    mMapDirectory.setPreload(true);
+                    return mMapDirectory;
                 }
             };
         } else if (dirImpl.equals("NIOFSDirectory")) {

--- a/src/main/java/org/apache/platypus/server/luceneserver/IndexState.java
+++ b/src/main/java/org/apache/platypus/server/luceneserver/IndexState.java
@@ -129,7 +129,7 @@ public class IndexState implements Closeable, Restorable {
     /**
      * Creates directories
      */
-    public DirectoryFactory df = DirectoryFactory.get("FSDirectory");
+    public DirectoryFactory df = DirectoryFactory.get("MMapDirectory");
 
     public final Path rootDir;
 

--- a/src/test/java/org/apache/platypus/server/YelpReviewsTest.java
+++ b/src/test/java/org/apache/platypus/server/YelpReviewsTest.java
@@ -467,7 +467,7 @@ public class YelpReviewsTest {
 
     private static void ensureServersUp(LuceneServerClient serverClient) throws InterruptedException {
         int retry = 0;
-        final int RETRY_LIMIT = 5;
+        final int RETRY_LIMIT = 10;
         while (retry < RETRY_LIMIT) {
             try {
                 HealthCheckResponse health = serverClient.getBlockingStub().status(HealthCheckRequest.newBuilder().build());


### PR DESCRIPTION
Based of this Elasticsearch PR:
https://github.com/elastic/elasticsearch/pull/18880/files

which enables the [index.store.preload](https://www.elastic.co/guide/en/elasticsearch/reference/current/preload-data-to-file-system-cache.html) feature. We can update the Directory type we want via a `SettingsRequest`